### PR TITLE
Add FormProvenance profile for QuestionnaireResponse provenance tracking

### DIFF
--- a/input/fsh/QuestionnaireV3/Provenance.fsh
+++ b/input/fsh/QuestionnaireV3/Provenance.fsh
@@ -3,12 +3,25 @@ Id: form-activity
 Title: "Form Activity"
 Description: "Activities that can be performed on form fields and which will be tracked through provenance"
 * #user "User input" "Manually entered data by the user"
+* #manual "Manual input" "Manually entered data by the user without additional system assistance"
 * #static "Static value" "A preconfigured value that has been picked by a user. The values in the preset have been used to populate fields."
-  * #preset
-  * #initial-value
+  * #preset "Preset" "Populated by preset"
+  * #initial-value "Initial value" "Populated by an initial value"
 * #calculation "Calculation" "A calculation has been performed to populate a field based on a predefined expression or formula."
   * #fhirpath "FHIRPath calculation" "A calculation has been performed using a FHIRPath expression."
 * #ai "AI population" "An AI-algorithm has been generating values to populate form fields"
   * #speech-population "Speech-based population" "A speech to QuestionnaireResponse solution has generated the field values."
-  * #ai-clipboard "AI Clipboard" "An AI-engine has processed clipboard content" 
-* #data-import "Data Import" "Import of values from other resources potentially coming from external servers." 
+  * #ai-clipboard "AI Clipboard" "An AI-engine has processed clipboard content"
+* #data-import "Data Import" "Import of values from other resources potentially coming from external servers."
+* #submit "Submit" "Form has been submitted for review or final processing"
+* #amend "Amend" "Form has been amended or updated after initial submission"
+
+
+CodeSystem: AgentTypes
+Id: agent-types
+Title: "Agent Types"
+Description: "Agent Types that process data to populate form fields."
+* #fhirpath-engine "FHIRPath Engine" "FHIRPath expression engine"
+* #population-engine "Population Engine" "Engine that populates forms from external data sources"
+* #preset-engine "Preset Engine" "Engine that applies preset configurations"
+* #x-fhir-query-resolver "X-FHIR Query Resolver" "Resolves x-fhir-query extensions"

--- a/input/fsh/QuestionnaireV3/Provenance.fsh
+++ b/input/fsh/QuestionnaireV3/Provenance.fsh
@@ -25,3 +25,123 @@ Description: "Agent Types that process data to populate form fields."
 * #population-engine "Population Engine" "Engine that populates forms from external data sources"
 * #preset-engine "Preset Engine" "Engine that applies preset configurations"
 * #x-fhir-query-resolver "X-FHIR Query Resolver" "Resolves x-fhir-query extensions"
+
+
+ValueSet: FormActivityVS
+Id: form-activity-vs
+Title: "Form Activity ValueSet"
+Description: "Activities that can be performed on form fields"
+* include codes from system FormActivity
+
+
+ValueSet: AgentTypesVS
+Id: agent-types-vs
+Title: "Agent Types ValueSet"
+Description: "Types of automated agents that can populate form fields"
+* include codes from system AgentTypes
+
+
+Profile: FormProvenance
+Parent: Provenance
+Id: form-provenance
+Title: "Form Provenance"
+Description: "Profile for tracking the origin and method of data entry for form fields to support audit trails and transparency"
+* ^purpose = "Track the origin and method of data entry for form fields to support audit trails and transparency"
+
+// Target must reference QuestionnaireResponse and include targetElement
+* target 1..* MS
+* target only Reference(QuestionnaireResponse)
+* target.extension contains http://hl7.org/fhir/StructureDefinition/targetElement named targetElement 1..1 MS
+* target.extension[targetElement] ^short = "Specific item.linkId within the QuestionnaireResponse"
+* target.extension[targetElement] ^definition = "Points to the specific item.linkId within the referenced QuestionnaireResponse that this provenance applies to"
+
+// Activity must include Tiro activity code, optionally ISO lifecycle code
+* activity 1..1 MS
+* activity.coding 1..* MS
+* activity.coding ^slicing.discriminator.type = #pattern
+* activity.coding ^slicing.discriminator.path = "system"
+* activity.coding ^slicing.rules = #open
+* activity.coding ^slicing.description = "Slicing based on the code system"
+* activity.coding contains
+    tiroActivity 1..1 MS and
+    isoLifecycle 0..1 MS
+* activity.coding[tiroActivity].system = "http://fhir.tiro.health/CodeSystem/form-activity"
+* activity.coding[tiroActivity] from FormActivityVS (required)
+* activity.coding[tiroActivity] ^short = "Activity that was performed on the form field"
+* activity.coding[tiroActivity] ^definition = "The specific Tiro-defined activity that was performed to populate or modify the form field"
+* activity.coding[isoLifecycle].system = "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle"
+* activity.coding[isoLifecycle] ^short = "ISO 21089 lifecycle event"
+* activity.coding[isoLifecycle] ^definition = "Optional standard ISO 21089 lifecycle event corresponding to the activity"
+
+// Recorded timestamp is required
+* recorded 1..1 MS
+
+// Agent constraints
+* agent 1..* MS
+* agent.who 1..1 MS
+* agent.who only Reference(Practitioner or Patient or Device)
+* agent.type MS
+* agent.type from AgentTypesVS (extensible)
+* agent.type ^short = "Type of agent (for automated systems)"
+* agent.onBehalfOf MS
+* agent.onBehalfOf only Reference(Practitioner or Organization)
+
+
+// Example Instances
+
+Instance: prov-001
+InstanceOf: FormProvenance
+Usage: #example
+Title: "User Input Provenance Example"
+Description: "Example of provenance tracking for manually entered user data"
+* target.reference = "QuestionnaireResponse/qr-123"
+* target.extension[targetElement].valueUri = "item-456"
+* recorded = "2025-10-29T10:30:00Z"
+* activity.text = "Manually entered data by the user"
+* activity.coding[tiroActivity].system = "http://fhir.tiro.health/CodeSystem/form-activity"
+* activity.coding[tiroActivity].code = #user
+* activity.coding[tiroActivity].display = "User input"
+* activity.coding[isoLifecycle].system = "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle"
+* activity.coding[isoLifecycle].code = #originate
+* activity.coding[isoLifecycle].display = "Originate/Retain Record Lifecycle Event"
+* agent.who.reference = "Practitioner/pract-789"
+
+
+Instance: prov-002
+InstanceOf: FormProvenance
+Usage: #example
+Title: "AI Clipboard Population Provenance Example"
+Description: "Example of provenance tracking for AI-powered clipboard processing"
+* target.reference = "QuestionnaireResponse/qr-123"
+* target.extension[targetElement].valueUri = "item-789"
+* recorded = "2025-10-29T10:32:00Z"
+* activity.text = "An AI-engine has processed clipboard content"
+* activity.coding[tiroActivity].system = "http://fhir.tiro.health/CodeSystem/form-activity"
+* activity.coding[tiroActivity].code = #ai-clipboard
+* activity.coding[tiroActivity].display = "AI Clipboard"
+* activity.coding[isoLifecycle].system = "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle"
+* activity.coding[isoLifecycle].code = #originate
+* activity.coding[isoLifecycle].display = "Originate/Retain Record Lifecycle Event"
+* agent.who.display = "AI Engine"
+* agent.onBehalfOf.reference = "Practitioner/pract-789"
+
+
+Instance: prov-003
+InstanceOf: FormProvenance
+Usage: #example
+Title: "FHIRPath Calculation Provenance Example"
+Description: "Example of provenance tracking for automated FHIRPath calculations"
+* target.reference = "QuestionnaireResponse/qr-123"
+* target.extension[targetElement].valueUri = "item-999"
+* recorded = "2025-10-29T10:33:00Z"
+* activity.text = "A calculation has been performed using a FHIRPath expression"
+* activity.coding[tiroActivity].system = "http://fhir.tiro.health/CodeSystem/form-activity"
+* activity.coding[tiroActivity].code = #fhirpath
+* activity.coding[tiroActivity].display = "FHIRPath calculation"
+* activity.coding[isoLifecycle].system = "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle"
+* activity.coding[isoLifecycle].code = #originate
+* activity.coding[isoLifecycle].display = "Originate/Retain Record Lifecycle Event"
+* agent.type.coding.system = "http://fhir.tiro.health/CodeSystem/agent-types"
+* agent.type.coding.code = #fhirpath-engine
+* agent.type.coding.display = "FHIRPath Engine"
+* agent.who.display = "FHIRPath.js"

--- a/input/pagecontent/5_Provenance.md
+++ b/input/pagecontent/5_Provenance.md
@@ -1,0 +1,338 @@
+# Data Provenance Tracking
+
+## Overview
+
+Atticus uses FHIR Provenance resources to track the origin and lifecycle of data entered into forms. This enables full auditability and transparency about how each data field was populated, whether by manual user input, AI algorithms, calculations, or data imports.
+
+## Architecture
+
+### Core Concepts
+
+1. **Provenance Resource**: A FHIR resource that records the origin and changes to data
+2. **Target Element**: Links provenance to specific QuestionnaireResponse items using extensions
+3. **Activity Codes**: Describe what type of operation was performed
+4. **Agents**: Identify who or what performed the action
+
+### Key Components
+
+- **CodeSystem: FormActivity** (`http://fhir.tiro.health/CodeSystem/form-activity`) - Activities specific to form field population
+- **CodeSystem: ISO 21089 Lifecycle** (`http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle`) - Standard lifecycle events
+- **Extension: targetElement** (`http://hl7.org/fhir/StructureDefinition/targetElement`) - Links provenance to specific response items
+
+## Activity Types
+
+### User Input Activities
+
+| Code | Display | Description |
+|------|---------|-------------|
+| `user` | User input | Manually entered data by the user |
+| `manual` | Manual input | Manually entered data without system assistance |
+
+### Static Value Activities
+
+| Code | Display | Description |
+|------|---------|-------------|
+| `static` | Static value | Preconfigured value picked by a user |
+| `preset` | Preset | Populated by a preset configuration |
+| `initial-value` | Initial value | Populated by an initial value definition |
+
+### Calculation Activities
+
+| Code | Display | Description |
+|------|---------|-------------|
+| `calculation` | Calculation | A calculation has been performed based on an expression |
+| `fhirpath` | FHIRPath calculation | A calculation performed using FHIRPath expression |
+
+### AI-Powered Activities
+
+| Code | Display | Description |
+|------|---------|-------------|
+| `ai` | AI population | An AI algorithm has generated field values |
+| `speech-population` | Speech-based population | Speech-to-text solution generated the values |
+| `ai-clipboard` | AI Clipboard | AI engine processed clipboard content |
+
+### Data Import Activities
+
+| Code | Display | Description |
+|------|---------|-------------|
+| `data-import` | Data Import | Values imported from other resources or external servers |
+
+### Lifecycle Activities
+
+| Code | Display | Description |
+|------|---------|-------------|
+| `submit` | Submit | Form submitted for review or final processing |
+| `amend` | Amend | Form amended or updated after initial submission |
+
+## ISO 21089 Lifecycle Events
+
+Atticus uses standard ISO 21089 lifecycle events in combination with form-specific activities:
+
+- **originate**: Initial creation of data (most form population activities)
+- **amend**: Modification of existing data
+- **merge**: Combining data from multiple sources
+
+## Implementation
+
+### Creating Provenance Records
+
+When a form field is populated, a Provenance resource is created with:
+
+1. **Target**: Reference to the QuestionnaireResponse with `targetElement` extension pointing to the specific item.id
+2. **Activity**: Coding array combining form-specific activity and ISO 21089 lifecycle event
+3. **Recorded**: Timestamp when the activity occurred
+4. **Agent**: Who or what performed the action
+
+### Example: User Input
+
+```json
+{
+  "resourceType": "Provenance",
+  "id": "prov-001",
+  "target": [
+    {
+      "reference": "QuestionnaireResponse/qr-123",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/targetElement",
+          "valueUri": "item-456"
+        }
+      ]
+    }
+  ],
+  "recorded": "2025-10-29T10:30:00Z",
+  "activity": {
+    "text": "Manually entered data by the user",
+    "coding": [
+      {
+        "system": "http://fhir.tiro.health/CodeSystem/form-activity",
+        "code": "user",
+        "display": "User input"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle",
+        "code": "originate",
+        "display": "Originate/Retain Record Lifecycle Event"
+      }
+    ]
+  },
+  "agent": [
+    {
+      "who": {
+        "reference": "Practitioner/pract-789"
+      }
+    }
+  ]
+}
+```
+
+### Example: AI Clipboard Population
+
+```json
+{
+  "resourceType": "Provenance",
+  "id": "prov-002",
+  "target": [
+    {
+      "reference": "QuestionnaireResponse/qr-123",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/targetElement",
+          "valueUri": "item-789"
+        }
+      ]
+    }
+  ],
+  "recorded": "2025-10-29T10:32:00Z",
+  "activity": {
+    "text": "An AI-engine has processed clipboard content",
+    "coding": [
+      {
+        "system": "http://fhir.tiro.health/CodeSystem/form-activity",
+        "code": "ai",
+        "display": "AI population"
+      },
+      {
+        "system": "http://fhir.tiro.health/CodeSystem/form-activity",
+        "code": "ai-clipboard",
+        "display": "AI Clipboard"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle",
+        "code": "originate",
+        "display": "Originate/Retain Record Lifecycle Event"
+      }
+    ]
+  },
+  "agent": [
+    {
+      "who": {
+        "display": "AI Engine"
+      },
+      "onBehalfOf": {
+        "reference": "Practitioner/pract-789"
+      }
+    }
+  ]
+}
+```
+
+### Example: FHIRPath Calculation
+
+```json
+{
+  "resourceType": "Provenance",
+  "id": "prov-003",
+  "target": [
+    {
+      "reference": "QuestionnaireResponse/qr-123",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/targetElement",
+          "valueUri": "item-999"
+        }
+      ]
+    }
+  ],
+  "recorded": "2025-10-29T10:33:00Z",
+  "activity": {
+    "text": "A calculation has been performed using a FHIRPath expression",
+    "coding": [
+      {
+        "system": "http://fhir.tiro.health/CodeSystem/form-activity",
+        "code": "calculation",
+        "display": "Calculation"
+      },
+      {
+        "system": "http://fhir.tiro.health/CodeSystem/form-activity",
+        "code": "fhirpath",
+        "display": "FHIRPath calculation"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle",
+        "code": "originate",
+        "display": "Originate/Retain Record Lifecycle Event"
+      }
+    ]
+  },
+  "agent": [
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://fhir.tiro.health/CodeSystem/agent-types",
+            "code": "fhirpath-engine",
+            "display": "FHIRPath Engine"
+          }
+        ]
+      },
+      "who": {
+        "display": "FHIRPath.js"
+      }
+    }
+  ]
+}
+```
+
+## Agent Types
+
+Agents represent actors that perform or participate in actions:
+
+| Type | Display | Description |
+|------|---------|-------------|
+| `fhirpath-engine` | FHIRPath Engine | FHIRPath expression evaluation engine |
+| `population-engine` | Population Engine | Engine that populates forms from external data |
+| `preset-engine` | Preset Engine | Engine that applies preset configurations |
+
+### Agent Structure
+
+Agents can include:
+- **type**: Classification of the agent (using `agent-types` CodeSystem)
+- **role**: Specific roles the agent played in the activity
+- **who**: Reference or display name identifying the agent
+- **onBehalfOf**: Reference to who the agent was acting on behalf of (e.g., AI acting on behalf of a practitioner)
+
+## Frontend Integration
+
+### Provenance Class
+
+The TypeScript `Provenance` class (`frontend/packages/report-renderer/src/utils/Provenance.ts`) provides:
+
+- **Activity helpers**: Pre-configured activity definitions (ACTIVITY constant)
+- **Agent helpers**: Pre-configured agent instances (AGENTS constant)
+- **Builder pattern**: Fluent API for constructing provenance resources
+- **Validation**: Static methods like `isOriginate()` to check lifecycle state
+
+### FormDataBuilder Integration
+
+The `FormDataBuilder` class (`frontend/packages/report-renderer/src/utils/FormDataBuilder.ts`) automatically:
+
+1. Extracts provenance information when converting QuestionnaireResponse to form data
+2. Links provenance to form fields using the `targetElement` extension
+3. Attaches provenance metadata to field objects for UI display
+
+### Field Provenance Structure
+
+Each form field can include provenance metadata:
+
+```typescript
+interface IFieldProvenance {
+  id?: string;           // Provenance resource ID
+  activity: string;      // Activity code (e.g., "user", "ai", "fhirpath")
+  recorded?: string;     // ISO timestamp
+}
+```
+
+## Querying Provenance
+
+### Finding Provenance for a QuestionnaireResponse
+
+```http
+GET /Provenance?target=QuestionnaireResponse/qr-123
+```
+
+### Finding Provenance by Activity Type
+
+```http
+GET /Provenance?activity=http://fhir.tiro.health/CodeSystem/form-activity|ai
+```
+
+### Finding AI-Generated Data
+
+```http
+GET /Provenance?activity=http://fhir.tiro.health/CodeSystem/form-activity|ai
+```
+
+## Best Practices
+
+1. **Always Record Provenance**: Every data modification should have associated provenance
+2. **Use Hierarchical Codes**: Combine specific codes with parent codes (e.g., `ai-clipboard` with `ai`)
+3. **Include Timestamps**: Always populate the `recorded` field
+4. **Link to Specific Items**: Use `targetElement` extension to point to exact QuestionnaireResponse.item.id
+5. **Preserve Agents**: Include both automated agents and the user they're acting on behalf of
+6. **Track Amendments**: Use `amend` activity and ISO 21089 lifecycle when updating existing data
+
+## Use Cases
+
+### Audit Trail
+Track who entered what data and when, providing complete transparency for regulatory compliance.
+
+### Data Quality Assessment
+Identify fields populated by AI vs. manual entry to assess confidence levels.
+
+### Workflow Optimization
+Analyze which fields are frequently manually corrected after AI population to improve algorithms.
+
+### Regulatory Compliance
+Demonstrate compliance with requirements for tracking data provenance in clinical systems.
+
+### Data Lineage
+Trace data back to its source through the `entity` array with role "source" or "derivation".
+
+## Related Resources
+
+- [ISO 21089 Lifecycle CodeSystem](http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle)
+- [FHIR Provenance Resource](http://hl7.org/fhir/provenance.html)
+- [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)
+- [FormActivity CodeSystem](CodeSystem-form-activity.html)
+- [AgentTypes CodeSystem](CodeSystem-agent-types.html)

--- a/input/pagecontent/5_Provenance.md
+++ b/input/pagecontent/5_Provenance.md
@@ -23,46 +23,46 @@ Atticus uses FHIR Provenance resources to track the origin and lifecycle of data
 
 ### User Input Activities
 
-| Code | Display | Description |
-|------|---------|-------------|
-| `user` | User input | Manually entered data by the user |
+| Code     | Display      | Description                                     |
+| -------- | ------------ | ----------------------------------------------- |
+| `user`   | User input   | Manually entered data by the user               |
 | `manual` | Manual input | Manually entered data without system assistance |
 
 ### Static Value Activities
 
-| Code | Display | Description |
-|------|---------|-------------|
-| `static` | Static value | Preconfigured value picked by a user |
-| `preset` | Preset | Populated by a preset configuration |
+| Code            | Display       | Description                              |
+| --------------- | ------------- | ---------------------------------------- |
+| `static`        | Static value  | Preconfigured value picked by a user     |
+| `preset`        | Preset        | Populated by a preset configuration      |
 | `initial-value` | Initial value | Populated by an initial value definition |
 
 ### Calculation Activities
 
-| Code | Display | Description |
-|------|---------|-------------|
-| `calculation` | Calculation | A calculation has been performed based on an expression |
-| `fhirpath` | FHIRPath calculation | A calculation performed using FHIRPath expression |
+| Code          | Display              | Description                                             |
+| ------------- | -------------------- | ------------------------------------------------------- |
+| `calculation` | Calculation          | A calculation has been performed based on an expression |
+| `fhirpath`    | FHIRPath calculation | A calculation performed using FHIRPath expression       |
 
 ### AI-Powered Activities
 
-| Code | Display | Description |
-|------|---------|-------------|
-| `ai` | AI population | An AI algorithm has generated field values |
+| Code                | Display                 | Description                                  |
+| ------------------- | ----------------------- | -------------------------------------------- |
+| `ai`                | AI population           | An AI algorithm has generated field values   |
 | `speech-population` | Speech-based population | Speech-to-text solution generated the values |
-| `ai-clipboard` | AI Clipboard | AI engine processed clipboard content |
+| `ai-clipboard`      | AI Clipboard            | AI engine processed clipboard content        |
 
 ### Data Import Activities
 
-| Code | Display | Description |
-|------|---------|-------------|
+| Code          | Display     | Description                                              |
+| ------------- | ----------- | -------------------------------------------------------- |
 | `data-import` | Data Import | Values imported from other resources or external servers |
 
 ### Lifecycle Activities
 
-| Code | Display | Description |
-|------|---------|-------------|
-| `submit` | Submit | Form submitted for review or final processing |
-| `amend` | Amend | Form amended or updated after initial submission |
+| Code     | Display | Description                                      |
+| -------- | ------- | ------------------------------------------------ |
+| `submit` | Submit  | Form submitted for review or final processing    |
+| `amend`  | Amend   | Form amended or updated after initial submission |
 
 ## ISO 21089 Lifecycle Events
 
@@ -85,223 +85,34 @@ When a form field is populated, a Provenance resource is created with:
 
 ### Example: User Input
 
-```json
-{
-  "resourceType": "Provenance",
-  "id": "prov-001",
-  "target": [
-    {
-      "reference": "QuestionnaireResponse/qr-123",
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/StructureDefinition/targetElement",
-          "valueUri": "item-456"
-        }
-      ]
-    }
-  ],
-  "recorded": "2025-10-29T10:30:00Z",
-  "activity": {
-    "text": "Manually entered data by the user",
-    "coding": [
-      {
-        "system": "http://fhir.tiro.health/CodeSystem/form-activity",
-        "code": "user",
-        "display": "User input"
-      },
-      {
-        "system": "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle",
-        "code": "originate",
-        "display": "Originate/Retain Record Lifecycle Event"
-      }
-    ]
-  },
-  "agent": [
-    {
-      "who": {
-        "reference": "Practitioner/pract-789"
-      }
-    }
-  ]
-}
-```
+{% fragment Provenance/prov-001 JSON %}
 
 ### Example: AI Clipboard Population
 
-```json
-{
-  "resourceType": "Provenance",
-  "id": "prov-002",
-  "target": [
-    {
-      "reference": "QuestionnaireResponse/qr-123",
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/StructureDefinition/targetElement",
-          "valueUri": "item-789"
-        }
-      ]
-    }
-  ],
-  "recorded": "2025-10-29T10:32:00Z",
-  "activity": {
-    "text": "An AI-engine has processed clipboard content",
-    "coding": [
-      {
-        "system": "http://fhir.tiro.health/CodeSystem/form-activity",
-        "code": "ai",
-        "display": "AI population"
-      },
-      {
-        "system": "http://fhir.tiro.health/CodeSystem/form-activity",
-        "code": "ai-clipboard",
-        "display": "AI Clipboard"
-      },
-      {
-        "system": "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle",
-        "code": "originate",
-        "display": "Originate/Retain Record Lifecycle Event"
-      }
-    ]
-  },
-  "agent": [
-    {
-      "who": {
-        "display": "AI Engine"
-      },
-      "onBehalfOf": {
-        "reference": "Practitioner/pract-789"
-      }
-    }
-  ]
-}
-```
+{% fragment Provenance/prov-002 JSON %}
 
 ### Example: FHIRPath Calculation
 
-```json
-{
-  "resourceType": "Provenance",
-  "id": "prov-003",
-  "target": [
-    {
-      "reference": "QuestionnaireResponse/qr-123",
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/StructureDefinition/targetElement",
-          "valueUri": "item-999"
-        }
-      ]
-    }
-  ],
-  "recorded": "2025-10-29T10:33:00Z",
-  "activity": {
-    "text": "A calculation has been performed using a FHIRPath expression",
-    "coding": [
-      {
-        "system": "http://fhir.tiro.health/CodeSystem/form-activity",
-        "code": "calculation",
-        "display": "Calculation"
-      },
-      {
-        "system": "http://fhir.tiro.health/CodeSystem/form-activity",
-        "code": "fhirpath",
-        "display": "FHIRPath calculation"
-      },
-      {
-        "system": "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle",
-        "code": "originate",
-        "display": "Originate/Retain Record Lifecycle Event"
-      }
-    ]
-  },
-  "agent": [
-    {
-      "type": {
-        "coding": [
-          {
-            "system": "http://fhir.tiro.health/CodeSystem/agent-types",
-            "code": "fhirpath-engine",
-            "display": "FHIRPath Engine"
-          }
-        ]
-      },
-      "who": {
-        "display": "FHIRPath.js"
-      }
-    }
-  ]
-}
-```
+{% fragment Provenance/prov-003 JSON %}
 
 ## Agent Types
 
 Agents represent actors that perform or participate in actions:
 
-| Type | Display | Description |
-|------|---------|-------------|
-| `fhirpath-engine` | FHIRPath Engine | FHIRPath expression evaluation engine |
+| Type                | Display           | Description                                    |
+| ------------------- | ----------------- | ---------------------------------------------- |
+| `fhirpath-engine`   | FHIRPath Engine   | FHIRPath expression evaluation engine          |
 | `population-engine` | Population Engine | Engine that populates forms from external data |
-| `preset-engine` | Preset Engine | Engine that applies preset configurations |
+| `preset-engine`     | Preset Engine     | Engine that applies preset configurations      |
 
 ### Agent Structure
 
 Agents can include:
+
 - **type**: Classification of the agent (using `agent-types` CodeSystem)
 - **role**: Specific roles the agent played in the activity
 - **who**: Reference or display name identifying the agent
 - **onBehalfOf**: Reference to who the agent was acting on behalf of (e.g., AI acting on behalf of a practitioner)
-
-## Frontend Integration
-
-### Provenance Class
-
-The TypeScript `Provenance` class (`frontend/packages/report-renderer/src/utils/Provenance.ts`) provides:
-
-- **Activity helpers**: Pre-configured activity definitions (ACTIVITY constant)
-- **Agent helpers**: Pre-configured agent instances (AGENTS constant)
-- **Builder pattern**: Fluent API for constructing provenance resources
-- **Validation**: Static methods like `isOriginate()` to check lifecycle state
-
-### FormDataBuilder Integration
-
-The `FormDataBuilder` class (`frontend/packages/report-renderer/src/utils/FormDataBuilder.ts`) automatically:
-
-1. Extracts provenance information when converting QuestionnaireResponse to form data
-2. Links provenance to form fields using the `targetElement` extension
-3. Attaches provenance metadata to field objects for UI display
-
-### Field Provenance Structure
-
-Each form field can include provenance metadata:
-
-```typescript
-interface IFieldProvenance {
-  id?: string;           // Provenance resource ID
-  activity: string;      // Activity code (e.g., "user", "ai", "fhirpath")
-  recorded?: string;     // ISO timestamp
-}
-```
-
-## Querying Provenance
-
-### Finding Provenance for a QuestionnaireResponse
-
-```http
-GET /Provenance?target=QuestionnaireResponse/qr-123
-```
-
-### Finding Provenance by Activity Type
-
-```http
-GET /Provenance?activity=http://fhir.tiro.health/CodeSystem/form-activity|ai
-```
-
-### Finding AI-Generated Data
-
-```http
-GET /Provenance?activity=http://fhir.tiro.health/CodeSystem/form-activity|ai
-```
 
 ## Best Practices
 
@@ -315,18 +126,23 @@ GET /Provenance?activity=http://fhir.tiro.health/CodeSystem/form-activity|ai
 ## Use Cases
 
 ### Audit Trail
+
 Track who entered what data and when, providing complete transparency for regulatory compliance.
 
 ### Data Quality Assessment
+
 Identify fields populated by AI vs. manual entry to assess confidence levels.
 
 ### Workflow Optimization
+
 Analyze which fields are frequently manually corrected after AI population to improve algorithms.
 
 ### Regulatory Compliance
+
 Demonstrate compliance with requirements for tracking data provenance in clinical systems.
 
 ### Data Lineage
+
 Trace data back to its source through the `entity` array with role "source" or "derivation".
 
 ## Related Resources

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -16,11 +16,12 @@ This section discusses how to create and manage reports through backend API's. T
 
 4. Creating a new template
 
+5. [Data Provenance Tracking](./5_Provenance.html)
+Learn how Atticus tracks the origin and lifecycle of form data using FHIR Provenance resources.
 
-5. Managing Data Dictionaries
+6. Managing Data Dictionaries
 
-
-6. Creating a new project
+7. Creating a new project
 
 
 ## Cicero


### PR DESCRIPTION
## Summary

Implements GH issue #1787 by creating a FHIR profile that constrains the base Provenance resource for tracking the origin and method of data entry in QuestionnaireResponse form fields.

## Changes

### New FHIR Resources

1. **FormActivityVS ValueSet** (`form-activity-vs`)
   - Includes all codes from FormActivity CodeSystem
   - Used for binding the tiroActivity slice

2. **AgentTypesVS ValueSet** (`agent-types-vs`)
   - Includes all codes from AgentTypes CodeSystem
   - Used for binding agent.type

3. **FormProvenance Profile** (`form-provenance`)
   - Parent: Provenance
   - **Target:** 1..* MS, only Reference(QuestionnaireResponse), requires targetElement extension (1..1 MS)
   - **Activity coding:** Sliced with tiroActivity (1..1 MS, required) and isoLifecycle (0..1 MS, optional)
   - **Recorded:** 1..1 MS
   - **Agent:** 1..* MS with constrained who, type, and onBehalfOf references

### Updated Examples

- Updated prov-001, prov-002, prov-003 to use FormProvenance profile
- Fixed slice notation for activity.coding
- Simplified examples to use most specific activity codes

## Build Status

- ✅ SUSHI compilation: 0 Errors, 0 Warnings
- ✅ IG Publisher: Build completed successfully
- ✅ All examples validate against the profile

## Test Plan

- [x] SUSHI compiles without errors
- [x] IG Publisher builds successfully
- [x] FormProvenance profile generated in fsh-generated/resources/
- [x] ValueSets generated correctly
- [x] Example instances reference FormProvenance profile
- [x] No validation errors introduced

## Related Issues

Closes #1787

🤖 Generated with [Claude Code](https://claude.com/claude-code)