### PR TITLE
Add DictationProvider CodeSystem for Atticus report renderer

### DIFF
--- a/input/fsh/Terminology/CodeSystem.fsh
+++ b/input/fsh/Terminology/CodeSystem.fsh
@@ -24,3 +24,12 @@ Title: "Auto Generated Codes"
 Description: "Tiro.health Auto Generate Codes in case common standard CodeSystems are insufficïent."
 * ^url = "http://tiro.health/fhir/CodeSystem/auto-generated"
 * ^content = #not-present
+
+CodeSystem: DictationProvider
+Id: dictation-provider
+Title: "Dictation Provider"
+Description: "Dictation providers supported by the Atticus report renderer"
+* ^status = #active
+* ^content = #complete
+* #corti "Corti" "Corti AI dictation provider"
+* #squire "Squire" "Squire Health dictation provider"


### PR DESCRIPTION
## Summary
Added a new CodeSystem definition for dictation providers supported by the Atticus report renderer.

## Key Changes
- Created `DictationProvider` CodeSystem with ID `dictation-provider`
- Defined two supported dictation providers:
  - `corti`: Corti AI dictation provider
  - `squire`: Squire Health dictation provider
- Set CodeSystem status to `active` with `complete` content

## Implementation Details
The new CodeSystem is marked as complete, indicating that all possible codes are defined within this system. This supports the Atticus report renderer's integration with multiple dictation provider options.

https://claude.ai/code/session_017JhWBbgg6Wzydy7Q1fVLp9