### PR TITLE
feat(ig): document AI provenance and contextual-populate operation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,8 +45,9 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./output
-  # Deployment job
+  # Deployment job — only runs on push to master, not on PRs
   deploy:
+    if: github.event_name == 'push'
     permissions: write-all
     environment:
       name: github-pages

--- a/input/fsh/QuestionnaireV3/Provenance.fsh
+++ b/input/fsh/QuestionnaireV3/Provenance.fsh
@@ -1,3 +1,27 @@
+// =============================================================================
+// Form Provenance — CodeSystems, Extensions, Profile, and Examples
+// =============================================================================
+// Every field populated by the Atticus $populate operation receives a
+// FormProvenance resource describing how the value was obtained. Provenances
+// are returned as repeated parameter[name="provenance"] entries in the
+// $populate response Parameters (one per populated field).
+//
+// Agent codes:
+//   All automated Atticus engines use provenance-participant-type#assembler
+//   Source document authors use provenance-participant-type#author
+//
+// Note: the legacy AgentTypes CodeSystem below is retired; existing persisted
+// Provenance resources may still reference those codes.
+// =============================================================================
+
+
+// -----------------------------------------------------------------------------
+// FormActivity CodeSystem
+// -----------------------------------------------------------------------------
+// When dual-coding is needed (e.g. initial-expression + data-import), both
+// codes are included in activity.coding with system=form-activity.
+// -----------------------------------------------------------------------------
+
 CodeSystem: FormActivity
 Id: form-activity
 Title: "Form Activity"
@@ -6,30 +30,43 @@ Description: "Activities that can be performed on form fields and which will be 
 * ^caseSensitive = true
 * #user "User input" "Manually entered data by the user"
 * #manual "Manual input" "Manually entered data by the user without additional system assistance"
-* #static "Static value" "A preconfigured value that has been picked by a user. The values in the preset have been used to populate fields."
-  * #preset "Preset" "Populated by preset"
-  * #initial-value "Initial value" "Populated by an initial value"
-* #calculation "Calculation" "A calculation has been performed to populate a field based on a predefined expression or formula."
-  * #fhirpath "FHIRPath calculation" "A calculation has been performed using a FHIRPath expression."
-* #ai "AI population" "An AI-algorithm has been generating values to populate form fields"
-  * #speech-population "Speech-based population" "A speech to QuestionnaireResponse solution has generated the field values."
-  * #ai-clipboard "AI Clipboard" "An AI-engine has processed clipboard content"
-* #data-import "Data Import" "Import of values from other resources potentially coming from external servers."
+* #static "Static value" "A preconfigured value that has been set without active user choice"
+  * #preset "Preset" "Populated by a saved preset configuration"
+  * #initial-value "Initial value" "Populated by Questionnaire.item.initial"
+* #calculation "Calculation" "A value computed from a FHIRPath calculatedExpression"
+  * #fhirpath "FHIRPath calculation" "Deprecated — use #calculation for calculatedExpression or #initial-expression for initialExpression"
+* #ai "AI population" "An AI algorithm generated or extracted the value"
+  * #speech-population "Speech-based population" "A speech-to-text solution populated the field"
+  * #ai-clipboard "AI Clipboard" "An AI engine extracted the value from clinical document content"
+* #data-import "Data Import" "Import of values from FHIR resources or external data sources"
+  * #initial-expression "Initial expression" "Populated by evaluating Questionnaire.item.initialExpression against launch context or server data"
+  * #definition "Definition-based import" "Populated by matching Questionnaire.item.definition to a FHIR resource element"
 * #submit "Submit" "Form has been submitted for review or final processing"
 * #amend "Amend" "Form has been amended or updated after initial submission"
 
 
+// -----------------------------------------------------------------------------
+// AgentTypes CodeSystem — RETIRED
+// Replaced by http://terminology.hl7.org/CodeSystem/provenance-participant-type
+// Kept for backward-compatibility with persisted Provenance resources.
+// -----------------------------------------------------------------------------
+
 CodeSystem: AgentTypes
 Id: agent-types
-Title: "Agent Types"
-Description: "Agent Types that process data to populate form fields."
+Title: "Agent Types (Retired)"
+Description: "Retired. Agent type codes previously used in Provenance.agent.type. Use http://terminology.hl7.org/CodeSystem/provenance-participant-type (code: assembler) instead."
 * ^experimental = false
+* ^status = #retired
 * ^caseSensitive = true
 * #fhirpath-engine "FHIRPath Engine" "FHIRPath expression engine"
 * #population-engine "Population Engine" "Engine that populates forms from external data sources"
 * #preset-engine "Preset Engine" "Engine that applies preset configurations"
 * #x-fhir-query-resolver "X-FHIR Query Resolver" "Resolves x-fhir-query extensions"
 
+
+// -----------------------------------------------------------------------------
+// ValueSets
+// -----------------------------------------------------------------------------
 
 ValueSet: FormActivityVS
 Id: form-activity-vs
@@ -41,40 +78,114 @@ Description: "Activities that can be performed on form fields"
 
 ValueSet: AgentTypesVS
 Id: agent-types-vs
-Title: "Agent Types ValueSet"
-Description: "Types of automated agents that can populate form fields"
+Title: "Agent Types ValueSet (Retired)"
+Description: "Retired. Use ProvenanceAgentTypeVS instead."
 * ^experimental = false
+* ^status = #retired
 * include codes from system AgentTypes
 
+
+ValueSet: ProvenanceAgentTypeVS
+Id: provenance-agent-type-vs
+Title: "Provenance Agent Type Value Set"
+Description: "Standard FHIR agent type codes used in FormProvenance.agent.type. Automated Atticus engines use #assembler; source document authors use #author."
+* ^experimental = false
+* http://terminology.hl7.org/CodeSystem/provenance-participant-type#assembler "Assembler"
+* http://terminology.hl7.org/CodeSystem/provenance-participant-type#author "Author"
+
+
+// -----------------------------------------------------------------------------
+// Extensions
+// -----------------------------------------------------------------------------
 
 Extension: ProvenanceWhy
 Id: provenance-why
 Title: "Provenance Why (R6 Pre-adopt)"
-Description: "Pre-adoption of R6 Provenance.why — describes why the event recorded in this provenance occurred in textual form."
+Description: "Pre-adoption of R6 Provenance.why — describes why the event recorded in this provenance occurred in textual form. For AI-populated fields this captures the model's reasoning. Note: the backend currently stores reasoning in activity.text; ProvenanceWhy is the intended field going forward."
 Context: Provenance
 * value[x] only markdown
 
+
+Extension: HtmlElementId
+Id: html-element-id
+Title: "HTML Element ID"
+Description: "ID of a labeled HTML element (e.g. a span with a data-label attribute) within a DocumentReference attachment that the AI used as source text when extracting a field value. Multiple occurrences indicate multiple contributing spans. Enables UI source-highlighting."
+Context: Provenance.entity.what
+* value[x] only string
+
+
+// -----------------------------------------------------------------------------
+// Device instances — Atticus engine agents
+// Used as Provenance.agent.who for automated population.
+// Note: the backend uses integer Device IDs (Device/1 through Device/5);
+// these IG instances use descriptive IDs for readability.
+// -----------------------------------------------------------------------------
+
+Instance: atticus-fhirpath-engine
+InstanceOf: Device
+Usage: #example
+Title: "Atticus FHIRPath Engine"
+Description: "FHIRPath expression evaluation engine. Referenced as Provenance.agent.who when initialExpression or calculatedExpression is evaluated. Backend reference: Device/1."
+* displayName = "Atticus FHIRPath Engine"
+
+Instance: atticus-population-engine
+InstanceOf: Device
+Usage: #example
+Title: "Atticus Population Engine"
+Description: "Population engine that applies initial values, evaluates definitions, and handles repopulation. Backend reference: Device/2."
+* displayName = "Atticus Population Engine"
+
+Instance: atticus-preset-engine
+InstanceOf: Device
+Usage: #example
+Title: "Atticus Preset Engine"
+Description: "Preset engine that loads saved preset configurations onto form fields. Backend reference: Device/3."
+* displayName = "Atticus Preset Engine"
+
+Instance: atticus-ai-marking-engine
+InstanceOf: Device
+Usage: #example
+Title: "Atticus AI Marking Engine"
+Description: "AI engine that labels and marks clinical document HTML content for extraction. Backend reference: Device/4."
+* displayName = "Atticus AI Marking Engine"
+
+Instance: atticus-ai-population-engine
+InstanceOf: Device
+Usage: #example
+Title: "Atticus AI Population Engine"
+Description: "AI engine that extracts answer values from labeled clinical document content (contextual-populate). Backend reference: Device/5."
+* displayName = "Atticus AI Population Engine"
+
+
+// -----------------------------------------------------------------------------
+// FormProvenance Profile
+// -----------------------------------------------------------------------------
 
 Profile: FormProvenance
 Parent: Provenance
 Id: form-provenance
 Title: "Form Provenance"
-Description: "Profile for tracking the origin and method of data entry for form fields to support audit trails and transparency"
+Description: "Profile for tracking the origin and method of data entry for form fields to support audit trails and transparency. One FormProvenance resource is created per populated QuestionnaireResponse item."
 * ^purpose = "Track the origin and method of data entry for form fields to support audit trails and transparency"
 
-// Why (R6 pre-adopt) - reasoning/rationale for the activity
+// Why (R6 pre-adopt): AI reasoning / rationale.
+// Current backend state: reasoning is stored in activity.text (plain string).
+// ProvenanceWhy (markdown) is the intended field going forward.
 * extension contains ProvenanceWhy named why 0..1 MS
-* extension[why] ^short = "Why the event occurred (e.g. AI reasoning)"
-* extension[why] ^definition = "Textual explanation of why the recorded event occurred. For AI-populated fields, this captures the reasoning behind the AI's decision."
+* extension[why] ^short = "AI reasoning or rationale for the activity (R6 pre-adopt)"
+* extension[why] ^definition = "Textual explanation of why the recorded event occurred. For AI-populated fields, this captures the model's reasoning. Backend currently uses activity.text; this extension is the intended long-term location."
 
-// Target must reference QuestionnaireResponse and include targetElement
+// Target: always the enclosing QuestionnaireResponse, with targetElement pointing
+// to the specific item.id (a server-assigned UUID, not item.linkId).
 * target 1..* MS
 * target only Reference(QuestionnaireResponse)
 * target.extension contains http://hl7.org/fhir/StructureDefinition/targetElement named targetElement 1..1 MS
-* target.extension[targetElement] ^short = "Specific item.linkId within the QuestionnaireResponse"
-* target.extension[targetElement] ^definition = "Points to the specific item.linkId within the referenced QuestionnaireResponse that this provenance applies to"
+* target.extension[targetElement] ^short = "Specific item within the QuestionnaireResponse"
+* target.extension[targetElement] ^definition = "Points to a specific QuestionnaireResponse.item.id (a server-assigned UUID) within the referenced QuestionnaireResponse. Note: this is item.id, not item.linkId."
 
-// Activity must include Tiro activity code, optionally ISO lifecycle code
+// Activity: at least one Tiro form-activity code required.
+// For activities with a more specific child code (e.g. #definition), the backend
+// also includes the parent code (#data-import) as a second tiroActivity coding.
 * activity 1..1 MS
 * activity.coding 1..* MS
 * activity.coding ^slicing.discriminator.type = #pattern
@@ -82,31 +193,46 @@ Description: "Profile for tracking the origin and method of data entry for form 
 * activity.coding ^slicing.rules = #open
 * activity.coding ^slicing.description = "Slicing based on the code system"
 * activity.coding contains
-    tiroActivity 1..1 MS and
+    tiroActivity 1..* MS and
     isoLifecycle 0..1 MS
 * activity.coding[tiroActivity].system = "http://fhir.tiro.health/CodeSystem/form-activity"
 * activity.coding[tiroActivity] from FormActivityVS (required)
 * activity.coding[tiroActivity] ^short = "Activity that was performed on the form field"
-* activity.coding[tiroActivity] ^definition = "The specific Tiro-defined activity that was performed to populate or modify the form field"
+* activity.coding[tiroActivity] ^definition = "One or more Tiro-defined activity codes. When a specific child code is used (e.g. #definition), the parent code (#data-import) is also included."
 * activity.coding[isoLifecycle].system = "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle"
 * activity.coding[isoLifecycle] ^short = "ISO 21089 lifecycle event"
-* activity.coding[isoLifecycle] ^definition = "Optional standard ISO 21089 lifecycle event corresponding to the activity"
+* activity.coding[isoLifecycle] ^definition = "Optional standard ISO 21089 lifecycle event corresponding to the activity. Typically #originate for initial population."
 
 // Recorded timestamp is required
 * recorded 1..1 MS
 
-// Agent constraints
+// Agent: the automated system or user that performed the activity.
+// Automated Atticus engines use type=assembler and who=Device/{engine}.
 * agent 1..* MS
 * agent.who 1..1 MS
 * agent.who only Reference(Practitioner or Patient or Device)
 * agent.type MS
-* agent.type from AgentTypesVS (extensible)
-* agent.type ^short = "Type of agent (for automated systems)"
+* agent.type from ProvenanceAgentTypeVS (extensible)
+* agent.type ^short = "assembler for automated engines, author for source document authors"
 * agent.onBehalfOf MS
 * agent.onBehalfOf only Reference(Practitioner or Organization)
 
+// Entity: source resource used as input (required for AI clipboard and definition-based import).
+// For AI clipboard: entity.what references the DocumentReference; html-element-id extensions
+// identify the specific labeled spans that were used for extraction.
+* entity MS
+* entity.role MS
+* entity.what MS
+* entity.what.reference MS
+* entity.what.display MS
+* entity.what.extension contains HtmlElementId named htmlElementId 0..* MS
+* entity.what.extension[htmlElementId] ^short = "HTML element IDs from source document"
+* entity.what.extension[htmlElementId] ^definition = "IDs of labeled HTML elements in the DocumentReference attachment that contain the text the AI used to derive the answer. Enables source-highlighting in the UI."
 
-// Stub instances referenced by Provenance examples
+
+// -----------------------------------------------------------------------------
+// Stub instances referenced by examples
+// -----------------------------------------------------------------------------
 
 Instance: qr-123
 InstanceOf: QuestionnaireResponse
@@ -124,13 +250,26 @@ Title: "Example Practitioner"
 Description: "Stub Practitioner referenced by provenance examples"
 * name.text = "Dr. Example"
 
-// Example Instances
+Instance: doc-001
+InstanceOf: DocumentReference
+Usage: #example
+Title: "Example Clinical Document"
+Description: "Stub DocumentReference representing a referral letter, referenced by the AI clipboard provenance example"
+* status = #current
+* description = "Referral letter from AZ Monica"
+* content.attachment.contentType = #text/html
+* content.attachment.title = "Referral letter from AZ Monica"
+
+
+// -----------------------------------------------------------------------------
+// Examples
+// -----------------------------------------------------------------------------
 
 Instance: prov-001
 InstanceOf: FormProvenance
 Usage: #example
-Title: "User Input Provenance Example"
-Description: "Example of provenance tracking for manually entered user data"
+Title: "User Input Provenance"
+Description: "Provenance for a field manually entered by the treating clinician"
 * target.reference = "QuestionnaireResponse/qr-123"
 * target.extension[targetElement].valueUri = "item-456"
 * recorded = "2025-10-29T10:30:00Z"
@@ -147,42 +286,103 @@ Description: "Example of provenance tracking for manually entered user data"
 Instance: prov-002
 InstanceOf: FormProvenance
 Usage: #example
-Title: "AI Clipboard Population Provenance Example"
-Description: "Example of provenance tracking for AI-powered clipboard processing with reasoning"
+Title: "AI Clipboard Population Provenance"
+Description: "Provenance for a field extracted by AI from a clinical document (contextual-populate). The entity carries the source DocumentReference and html-element-id extensions identifying the specific labeled spans used for extraction."
+// ProvenanceWhy: structured AI reasoning (intended future location; backend currently uses activity.text)
 * extension[why].valueMarkdown = """
-  The clinical note states: "CT thorax toont een massa van 4.2cm in de rechter bovenkwab met invasie van de thoraxwand."
-  This indicates a tumor >4cm with chest wall invasion, corresponding to cT3 per AJCC 8th edition staging criteria.
-  """
+The clinical note states: "CT thorax toont een massa van 4.2cm in de rechter bovenkwab met invasie van de thoraxwand."
+This indicates a tumor >4cm with chest wall invasion, corresponding to cT3 per AJCC 8th edition staging criteria.
+"""
 * target.reference = "QuestionnaireResponse/qr-123"
 * target.extension[targetElement].valueUri = "item-789"
 * recorded = "2025-10-29T10:32:00Z"
-* activity.text = "An AI-engine has processed clipboard content"
+// activity.text carries the AI reasoning in the current backend implementation
+* activity.text = "CT toont massa van 4.2cm in rechter bovenkwab met thoraxwandinvasie → cT3 (AJCC 8th)"
 * activity.coding[tiroActivity].system = "http://fhir.tiro.health/CodeSystem/form-activity"
 * activity.coding[tiroActivity].code = #ai-clipboard
 * activity.coding[tiroActivity].display = "AI Clipboard"
 * activity.coding[isoLifecycle].system = "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle"
 * activity.coding[isoLifecycle].code = #originate
 * activity.coding[isoLifecycle].display = "Originate/Retain Record Lifecycle Event"
-* agent.who.display = "AI Engine"
-* agent.onBehalfOf.reference = "Practitioner/pract-789"
+* agent.type.coding.system = "http://terminology.hl7.org/CodeSystem/provenance-participant-type"
+* agent.type.coding.code = #assembler
+* agent.type.coding.display = "Assembler"
+* agent.who.reference = "Device/atticus-ai-population-engine"
+* entity.role = #source
+* entity.what.reference = "DocumentReference/doc-001"
+* entity.what.display = "Referral letter from AZ Monica"
+* entity.what.extension[htmlElementId][+].valueString = "label-001"
+* entity.what.extension[htmlElementId][+].valueString = "label-002"
 
 
 Instance: prov-003
 InstanceOf: FormProvenance
 Usage: #example
-Title: "FHIRPath Calculation Provenance Example"
-Description: "Example of provenance tracking for automated FHIRPath calculations"
+Title: "FHIRPath Calculation Provenance"
+Description: "Provenance for a field computed by the FHIRPath engine from a calculatedExpression"
 * target.reference = "QuestionnaireResponse/qr-123"
 * target.extension[targetElement].valueUri = "item-999"
 * recorded = "2025-10-29T10:33:00Z"
-* activity.text = "A calculation has been performed using a FHIRPath expression"
+* activity.text = "A value computed from a FHIRPath calculatedExpression"
 * activity.coding[tiroActivity].system = "http://fhir.tiro.health/CodeSystem/form-activity"
-* activity.coding[tiroActivity].code = #fhirpath
-* activity.coding[tiroActivity].display = "FHIRPath calculation"
+* activity.coding[tiroActivity].code = #calculation
+* activity.coding[tiroActivity].display = "Calculation"
 * activity.coding[isoLifecycle].system = "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle"
 * activity.coding[isoLifecycle].code = #originate
 * activity.coding[isoLifecycle].display = "Originate/Retain Record Lifecycle Event"
-* agent.type.coding.system = "http://fhir.tiro.health/CodeSystem/agent-types"
-* agent.type.coding.code = #fhirpath-engine
-* agent.type.coding.display = "FHIRPath Engine"
-* agent.who.display = "FHIRPath.js"
+* agent.type.coding.system = "http://terminology.hl7.org/CodeSystem/provenance-participant-type"
+* agent.type.coding.code = #assembler
+* agent.type.coding.display = "Assembler"
+* agent.who.reference = "Device/atticus-fhirpath-engine"
+
+
+Instance: prov-004
+InstanceOf: FormProvenance
+Usage: #example
+Title: "Definition-Based Import Provenance"
+Description: "Provenance for a field populated by matching Questionnaire.item.definition to a FHIR Observation. The backend sends both #definition and #data-import as tiroActivity codings."
+* target.reference = "QuestionnaireResponse/qr-123"
+* target.extension[targetElement].valueUri = "item-444"
+* recorded = "2025-10-29T10:34:00Z"
+* activity.coding[tiroActivity][+].system = "http://fhir.tiro.health/CodeSystem/form-activity"
+* activity.coding[tiroActivity][=].code = #definition
+* activity.coding[tiroActivity][=].display = "Definition-based import"
+* activity.coding[tiroActivity][+].system = "http://fhir.tiro.health/CodeSystem/form-activity"
+* activity.coding[tiroActivity][=].code = #data-import
+* activity.coding[tiroActivity][=].display = "Data Import"
+* activity.coding[isoLifecycle].system = "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle"
+* activity.coding[isoLifecycle].code = #originate
+* activity.coding[isoLifecycle].display = "Originate/Retain Record Lifecycle Event"
+* agent.type.coding.system = "http://terminology.hl7.org/CodeSystem/provenance-participant-type"
+* agent.type.coding.code = #assembler
+* agent.type.coding.display = "Assembler"
+* agent.who.reference = "Device/atticus-population-engine"
+* entity.role = #source
+* entity.what.reference = "Observation/obs-789"
+* entity.what.display = "Serum Creatinine Lab Result"
+
+
+Instance: prov-005
+InstanceOf: FormProvenance
+Usage: #example
+Title: "Preset Population Provenance"
+Description: "Provenance for fields populated from a saved preset configuration. The backend sends both #preset and #static as tiroActivity codings."
+* target.reference = "QuestionnaireResponse/qr-123"
+* target.extension[targetElement].valueUri = "item-555"
+* recorded = "2025-10-29T10:35:00Z"
+* activity.coding[tiroActivity][+].system = "http://fhir.tiro.health/CodeSystem/form-activity"
+* activity.coding[tiroActivity][=].code = #preset
+* activity.coding[tiroActivity][=].display = "Preset"
+* activity.coding[tiroActivity][+].system = "http://fhir.tiro.health/CodeSystem/form-activity"
+* activity.coding[tiroActivity][=].code = #static
+* activity.coding[tiroActivity][=].display = "Static value"
+* activity.coding[isoLifecycle].system = "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle"
+* activity.coding[isoLifecycle].code = #originate
+* activity.coding[isoLifecycle].display = "Originate/Retain Record Lifecycle Event"
+* agent.type.coding.system = "http://terminology.hl7.org/CodeSystem/provenance-participant-type"
+* agent.type.coding.code = #assembler
+* agent.type.coding.display = "Assembler"
+* agent.who.reference = "Device/atticus-preset-engine"
+* entity.role = #source
+* entity.what.reference = "Basic/preset-mri-protocol"
+* entity.what.display = "MRI Protocol Preset"

--- a/input/fsh/ReportServer/Population.fsh
+++ b/input/fsh/ReportServer/Population.fsh
@@ -1,3 +1,116 @@
+// =============================================================================
+// $populate Operation — Population Modes and Provenance Output
+// =============================================================================
+// The Tiro $populate operation extends the SDC Questionnaire/$populate
+// operation with three population modes and a provenance output parameter.
+//
+// Population modes (parameter name="mode"):
+//   pre-populate        — Evaluate initialExpression / item.initial at form launch.
+//   re-populate         — Re-run population on an existing QuestionnaireResponse.
+//   contextual-populate — AI-driven extraction from clinical document context.
+//
+// Contextual-populate specifics:
+//   Accepts a context parameter with name="clinical-artifacts" containing one or
+//   more DocumentReference resources (base64-encoded HTML or PDF attachments).
+//   The AI marking pipeline processes up to 5 documents in parallel, labels HTML
+//   spans, and extracts answer values per questionnaire item.
+//
+// Provenance output:
+//   The response Parameters includes one parameter[name="provenance"] entry per
+//   populated field, each carrying a FormProvenance resource.
+//   Each Provenance links to its field via:
+//     target[0].reference = "#"                       (the QuestionnaireResponse)
+//     target[0].extension[targetElement].valueUri     (QuestionnaireResponse.item.id — a UUID)
+//   For AI clipboard: entity.what references the source DocumentReference, and
+//   entity.what.extension[html-element-id] carries the labeled span IDs that
+//   support source-highlighting in the UI.
+// =============================================================================
+
+
+Instance: TiroPopulate
+InstanceOf: OperationDefinition
+Usage: #definition
+Title: "Tiro Questionnaire $populate"
+Description: "Populate a Questionnaire with pre-existing data or AI-extracted values from clinical documents. Extends SDC Questionnaire/$populate with the contextual-populate mode and a provenance output parameter."
+* name = "TiroPopulate"
+* status = #active
+* kind = #operation
+* code = #populate
+* resource[+] = #Questionnaire
+* system = false
+* type = true
+* instance = true
+* parameter[+]
+  * name = #questionnaire
+  * use = #in
+  * min = 0
+  * max = "1"
+  * type = #canonical
+  * documentation = "Canonical URL (optionally versioned) of the Questionnaire to populate. If the operation is invoked on a Questionnaire instance, this parameter is optional."
+* parameter[+]
+  * name = #subject
+  * use = #in
+  * min = 0
+  * max = "1"
+  * type = #Reference
+  * documentation = "Patient resource or reference used as the population subject."
+* parameter[+]
+  * name = #mode
+  * use = #in
+  * min = 0
+  * max = "1"
+  * type = #string
+  * documentation = "Population mode: pre-populate | re-populate | contextual-populate. Defaults to pre-populate."
+* parameter[+]
+  * name = #context
+  * use = #in
+  * min = 0
+  * max = "*"
+  * documentation = "Named context groups providing data for population. For contextual-populate, include a group with name='clinical-artifacts'."
+  * part[+]
+    * name = #name
+    * use = #in
+    * min = 1
+    * max = "1"
+    * type = #string
+    * documentation = "Context group name (e.g. 'clinical-artifacts')."
+  * part[+]
+    * name = #content
+    * use = #in
+    * min = 0
+    * max = "*"
+    * type = #Reference
+    * documentation = "Content resource for this context group (e.g. a DocumentReference with an HTML or PDF attachment)."
+* parameter[+]
+  * name = #responseCandidate
+  * use = #in
+  * min = 0
+  * max = "1"
+  * type = #QuestionnaireResponse
+  * documentation = "Existing QuestionnaireResponse used as the base for re-populate mode."
+* parameter[+]
+  * name = #response
+  * use = #out
+  * min = 1
+  * max = "1"
+  * type = #QuestionnaireResponse
+  * documentation = "The populated QuestionnaireResponse."
+* parameter[+]
+  * name = #issues
+  * use = #out
+  * min = 0
+  * max = "1"
+  * type = #OperationOutcome
+  * documentation = "Issues encountered during population (warnings, errors)."
+* parameter[+]
+  * name = #provenance
+  * use = #out
+  * min = 0
+  * max = "*"
+  * type = #Provenance
+  * documentation = "One FormProvenance per populated field, describing how the value was obtained. Repeated — one entry per item. Each Provenance.target[0].extension[targetElement].valueUri points to the QuestionnaireResponse.item.id of the populated field."
+
+
 Profile: Report
 Parent: Bundle
 Id: Report
@@ -31,8 +144,8 @@ Description: "Report Template represented as FHIR Questionnaire with references 
 Instance: PopulationRequest
 InstanceOf: Parameters
 Usage: #example
-Title: "Population Request"
-Description: "Request for a population of patients."
+Title: "Population Request (pre-populate)"
+Description: "Example pre-populate request: evaluates initialExpression and item.initial at form launch."
 * parameter[+]
   * name = "questionnaire"
   * resource = ReportTemplate
@@ -42,3 +155,49 @@ Description: "Request for a population of patients."
 * parameter[+]
   * name = "encounter"
   * valueReference = Reference(LCaStagingEncounter)
+
+
+// -----------------------------------------------------------------------------
+// Contextual-populate example
+// Shows the request Parameters and a representative response Parameters
+// with one QuestionnaireResponse and one FormProvenance entry.
+// -----------------------------------------------------------------------------
+
+Instance: ContextualPopulateRequest
+InstanceOf: Parameters
+Usage: #example
+Title: "Contextual Populate Request"
+Description: "Example contextual-populate request supplying a clinical DocumentReference as AI context. The AI marking pipeline extracts field values and returns one FormProvenance per populated item."
+* parameter[+]
+  * name = "questionnaire"
+  * valueCanonical = "http://fhir.tiro.health/Questionnaire/lca-staging|1.2.0"
+* parameter[+]
+  * name = "subject"
+  * valueReference.reference = "Patient/patient-123"
+  * valueReference.display = "Jan Janssen"
+* parameter[+]
+  * name = "mode"
+  * valueString = "contextual-populate"
+* parameter[+]
+  * name = "context"
+  * part[+]
+    * name = "name"
+    * valueString = "clinical-artifacts"
+  * part[+]
+    * name = "content"
+    * valueReference.reference = "DocumentReference/doc-001"
+    * valueReference.display = "Referral letter from AZ Monica"
+
+
+Instance: ContextualPopulateResponse
+InstanceOf: Parameters
+Usage: #example
+Title: "Contextual Populate Response"
+Description: "Example $populate response for contextual-populate mode. Includes the populated QuestionnaireResponse and one FormProvenance entry per populated field. In practice, provenance is repeated once per field."
+* parameter[+]
+  * name = "response"
+  * resource = qr-123
+// One provenance parameter per populated field (repeated):
+* parameter[+]
+  * name = "provenance"
+  * resource = prov-002

--- a/input/pagecontent/5_Provenance.md
+++ b/input/pagecontent/5_Provenance.md
@@ -2,153 +2,158 @@
 
 ## Overview
 
-Atticus uses FHIR Provenance resources to track the origin and lifecycle of data entered into forms. This enables full auditability and transparency about how each data field was populated, whether by manual user input, AI algorithms, calculations, or data imports.
+Atticus uses FHIR Provenance resources to track the origin and lifecycle of every field populated in a QuestionnaireResponse. This enables full auditability — whether a value was entered manually, extracted by AI, computed by a FHIRPath expression, or loaded from a preset.
 
-## Architecture
+Each populated field receives its own [`FormProvenance`](StructureDefinition-form-provenance.html) resource. These are returned as repeated `parameter[name="provenance"]` entries alongside the QuestionnaireResponse in the [`$populate`](OperationDefinition-tiro-populate.html) response.
 
-### Core Concepts
+## How Provenance Is Linked to a Field
 
-1. **Provenance Resource**: A FHIR resource that records the origin and changes to data
-2. **Target Element**: Links provenance to specific QuestionnaireResponse items using extensions
-3. **Activity Codes**: Describe what type of operation was performed
-4. **Agents**: Identify who or what performed the action
+Each Provenance targets the enclosing QuestionnaireResponse and identifies the specific populated item via the standard [`targetElement`](https://hl7.org/fhir/extensions/StructureDefinition-targetElement.html) extension:
 
-### Key Components
+```
+Provenance.target[0].reference = "#"                        ← the QuestionnaireResponse
+Provenance.target[0].extension[targetElement].valueUri      ← QuestionnaireResponse.item.id (a UUID)
+```
 
-- **CodeSystem: FormActivity** (`http://fhir.tiro.health/CodeSystem/form-activity`) - Activities specific to form field population
-- **CodeSystem: ISO 21089 Lifecycle** (`http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle`) - Standard lifecycle events
-- **Extension: targetElement** (`http://hl7.org/fhir/StructureDefinition/targetElement`) - Links provenance to specific response items
+Note: `targetElement` carries the item's **`id`** (a server-assigned UUID), not its `linkId`.
 
-## Activity Types
+## Activity Codes
 
-### User Input Activities
+Every Provenance carries at least one [`FormActivity`](CodeSystem-form-activity.html) code in `activity.coding` plus an optional [ISO 21089 lifecycle](http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle) code. For activities that have a specific child code, the backend also includes the parent code (e.g. `definition` + `data-import`).
 
-| Code     | Display      | Description                                     |
-| -------- | ------------ | ----------------------------------------------- |
-| `user`   | User input   | Manually entered data by the user               |
-| `manual` | Manual input | Manually entered data without system assistance |
+### User Input
 
-### Static Value Activities
+| Code | Description |
+|------|-------------|
+| `user` | Manually entered by the clinician |
+| `manual` | Manual input without system assistance |
 
-| Code            | Display       | Description                              |
-| --------------- | ------------- | ---------------------------------------- |
-| `static`        | Static value  | Preconfigured value picked by a user     |
-| `preset`        | Preset        | Populated by a preset configuration      |
-| `initial-value` | Initial value | Populated by an initial value definition |
+### Static Values
 
-### Calculation Activities
+| Code | Description |
+|------|-------------|
+| `static` | Preconfigured value set without active user choice |
+| `preset` | Loaded from a saved preset configuration |
+| `initial-value` | Populated by `Questionnaire.item.initial` |
 
-| Code          | Display              | Description                                             |
-| ------------- | -------------------- | ------------------------------------------------------- |
-| `calculation` | Calculation          | A calculation has been performed based on an expression |
-| `fhirpath`    | FHIRPath calculation | A calculation performed using FHIRPath expression       |
+### Calculations
 
-### AI-Powered Activities
+| Code | Description |
+|------|-------------|
+| `calculation` | Computed from a `calculatedExpression` (FHIRPath) |
 
-| Code                | Display                 | Description                                  |
-| ------------------- | ----------------------- | -------------------------------------------- |
-| `ai`                | AI population           | An AI algorithm has generated field values   |
-| `speech-population` | Speech-based population | Speech-to-text solution generated the values |
-| `ai-clipboard`      | AI Clipboard            | AI engine processed clipboard content        |
+### AI-Powered
 
-### Data Import Activities
+| Code | Description |
+|------|-------------|
+| `ai` | Generic AI population |
+| `ai-clipboard` | AI extraction from a clinical document (contextual-populate) |
+| `speech-population` | Speech-to-text population |
 
-| Code          | Display     | Description                                              |
-| ------------- | ----------- | -------------------------------------------------------- |
-| `data-import` | Data Import | Values imported from other resources or external servers |
+### Data Import
 
-### Lifecycle Activities
+| Code | Description |
+|------|-------------|
+| `data-import` | Import from FHIR resources or external data sources |
+| `initial-expression` | Evaluated from `Questionnaire.item.initialExpression` — sent alongside `data-import` |
+| `definition` | Matched via `Questionnaire.item.definition` to a FHIR resource — sent alongside `data-import` |
 
-| Code     | Display | Description                                      |
-| -------- | ------- | ------------------------------------------------ |
-| `submit` | Submit  | Form submitted for review or final processing    |
-| `amend`  | Amend   | Form amended or updated after initial submission |
+### ISO 21089 Lifecycle
 
-## ISO 21089 Lifecycle Events
+| Code | Description |
+|------|-------------|
+| `originate` | Initial creation (used for all population activities) |
+| `amend` | Modification of existing data |
+| `merge` | Combining data from multiple sources |
 
-Atticus uses standard ISO 21089 lifecycle events in combination with form-specific activities:
+## Agents
 
-- **originate**: Initial creation of data (most form population activities)
-- **amend**: Modification of existing data
-- **merge**: Combining data from multiple sources
+All automated Atticus engines use `provenance-participant-type#assembler` as the agent type and a `Device` resource as `agent.who`. Source document authors (for AI clipboard) use `provenance-participant-type#author`.
 
-## Implementation
+| Device | Display | Used for |
+|--------|---------|----------|
+| `Device/atticus-fhirpath-engine` | Atticus FHIRPath Engine | `initialExpression`, `calculatedExpression` |
+| `Device/atticus-population-engine` | Atticus Population Engine | Initial values, repopulation, definition import |
+| `Device/atticus-preset-engine` | Atticus Preset Engine | Preset loading |
+| `Device/atticus-ai-marking-engine` | Atticus AI Marking Engine | HTML marking (labeling) |
+| `Device/atticus-ai-population-engine` | Atticus AI Population Engine | AI clipboard extraction |
 
-### Creating Provenance Records
+> **Note:** The backend uses integer Device IDs `Device/1`–`Device/5`; the IG uses descriptive IDs for readability.
 
-When a form field is populated, a Provenance resource is created with:
+The legacy [`AgentTypes`](CodeSystem-agent-types.html) CodeSystem (`fhirpath-engine`, `population-engine`, etc.) is retired. Existing persisted Provenance resources may still reference those codes.
 
-1. **Target**: Reference to the QuestionnaireResponse with `targetElement` extension pointing to the specific item.id
-2. **Activity**: Coding array combining form-specific activity and ISO 21089 lifecycle event
-3. **Recorded**: Timestamp when the activity occurred
-4. **Agent**: Who or what performed the action
+## AI Reasoning — ProvenanceWhy and activity.text
 
-### Example: User Input
+For AI-populated fields, the model's reasoning can be recorded in two places:
+
+- **`activity.text`**: Plain-string reasoning. This is what the backend currently populates.
+- **`extension[why]`** ([`ProvenanceWhy`](StructureDefinition-provenance-why.html)): Markdown reasoning — a pre-adoption of the R6 `Provenance.why` element. This is the intended location going forward.
+
+## AI Clipboard: Source Highlighting
+
+When `contextual-populate` extracts a value from a clinical document, the Provenance includes an `entity` pointing to the source `DocumentReference`. The [`html-element-id`](StructureDefinition-html-element-id.html) extension on `entity.what` carries the IDs of the labeled HTML spans that contained the extracted text — enabling the UI to highlight the source passage:
+
+```
+Provenance.entity[0].role = "source"
+Provenance.entity[0].what.reference = "DocumentReference/{id}"
+Provenance.entity[0].what.extension[html-element-id][0].valueString = "label-001"
+Provenance.entity[0].what.extension[html-element-id][1].valueString = "label-002"
+```
+
+## The $populate Response Shape
+
+The [`$populate`](OperationDefinition-tiro-populate.html) response is a `Parameters` resource with one entry per populated field:
+
+```
+Parameters
+├─ parameter[name="response"].resource     → QuestionnaireResponse
+├─ parameter[name="issues"].resource       → OperationOutcome (optional)
+└─ parameter[name="provenance"].resource   → FormProvenance  ← repeated, one per field
+   └─ parameter[name="provenance"].resource → FormProvenance
+   ...
+```
+
+### Contextual-Populate Flow
+
+`contextual-populate` mode accepts clinical documents as context and drives the full AI pipeline:
+
+1. Request supplies `context[name="clinical-artifacts"]` with one or more `DocumentReference` resources (HTML or PDF attachments).
+2. The AI marking pipeline processes up to 5 documents in parallel: labels HTML spans, identifies which spans correspond to each questionnaire item, and extracts answer values.
+3. Each extracted value gets a `FormProvenance` with:
+   - `activity.coding` = `ai-clipboard` + `data-import`
+   - `agent.who` = `Device/atticus-ai-population-engine`
+   - `entity.what.reference` = the source `DocumentReference`
+   - `entity.what.extension[html-element-id]` = span IDs for source highlighting
+   - `activity.text` (and/or `extension[why]`) = the model's reasoning
+
+## Examples
+
+### User Input
 
 {% fragment Provenance/prov-001 JSON %}
 
-### Example: AI Clipboard Population
+### AI Clipboard Population
 
 {% fragment Provenance/prov-002 JSON %}
 
-### Example: FHIRPath Calculation
+### FHIRPath Calculation
 
 {% fragment Provenance/prov-003 JSON %}
 
-## Agent Types
+### Definition-Based Import
 
-Agents represent actors that perform or participate in actions:
+{% fragment Provenance/prov-004 JSON %}
 
-| Type                | Display           | Description                                    |
-| ------------------- | ----------------- | ---------------------------------------------- |
-| `fhirpath-engine`   | FHIRPath Engine   | FHIRPath expression evaluation engine          |
-| `population-engine` | Population Engine | Engine that populates forms from external data |
-| `preset-engine`     | Preset Engine     | Engine that applies preset configurations      |
+### Preset Population
 
-### Agent Structure
-
-Agents can include:
-
-- **type**: Classification of the agent (using `agent-types` CodeSystem)
-- **role**: Specific roles the agent played in the activity
-- **who**: Reference or display name identifying the agent
-- **onBehalfOf**: Reference to who the agent was acting on behalf of (e.g., AI acting on behalf of a practitioner)
-
-## Best Practices
-
-1. **Always Record Provenance**: Every data modification should have associated provenance
-2. **Use Hierarchical Codes**: Combine specific codes with parent codes (e.g., `ai-clipboard` with `ai`)
-3. **Include Timestamps**: Always populate the `recorded` field
-4. **Link to Specific Items**: Use `targetElement` extension to point to exact QuestionnaireResponse.item.id
-5. **Preserve Agents**: Include both automated agents and the user they're acting on behalf of
-6. **Track Amendments**: Use `amend` activity and ISO 21089 lifecycle when updating existing data
-
-## Use Cases
-
-### Audit Trail
-
-Track who entered what data and when, providing complete transparency for regulatory compliance.
-
-### Data Quality Assessment
-
-Identify fields populated by AI vs. manual entry to assess confidence levels.
-
-### Workflow Optimization
-
-Analyze which fields are frequently manually corrected after AI population to improve algorithms.
-
-### Regulatory Compliance
-
-Demonstrate compliance with requirements for tracking data provenance in clinical systems.
-
-### Data Lineage
-
-Trace data back to its source through the `entity` array with role "source" or "derivation".
+{% fragment Provenance/prov-005 JSON %}
 
 ## Related Resources
 
+- [FormProvenance profile](StructureDefinition-form-provenance.html)
+- [FormActivity CodeSystem](CodeSystem-form-activity.html)
+- [$populate OperationDefinition](OperationDefinition-tiro-populate.html)
+- [ProvenanceWhy extension](StructureDefinition-provenance-why.html)
+- [HtmlElementId extension](StructureDefinition-html-element-id.html)
 - [ISO 21089 Lifecycle CodeSystem](http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle)
 - [FHIR Provenance Resource](http://hl7.org/fhir/provenance.html)
-- [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)
-- [FormActivity CodeSystem](CodeSystem-form-activity.html)
-- [AgentTypes CodeSystem](CodeSystem-agent-types.html)


### PR DESCRIPTION
## Summary

- **FormActivity CodeSystem**: adds `#initial-expression` and `#definition` codes (children of `#data-import`) used by the backend; flags `#fhirpath` as deprecated
- **AgentTypes**: retires legacy CodeSystem/ValueSet; introduces `ProvenanceAgentTypeVS` binding to standard `provenance-participant-type#assembler`/`author`
- **HtmlElementId extension**: new extension on `Provenance.entity.what` for AI source-highlighting (span IDs in DocumentReference HTML)
- **Device instances**: five `Device` instances for Atticus engines (`atticus-fhirpath-engine` → `atticus-ai-population-engine`) with notes mapping to backend integer IDs
- **FormProvenance profile**: widens `tiroActivity` slice to `1..*` (backend sends dual codes), fixes `targetElement` doc to reference `item.id` (UUID), adds entity constraints, updates `agent.type` binding
- **Examples**: updates prov-002/003 to use standard agent codes + Device refs; adds prov-004 (definition import) and prov-005 (preset)
- **`$populate` OperationDefinition**: formal definition with all in/out parameters including the repeated `provenance` output (one `FormProvenance` per populated field)
- **Contextual-populate examples**: request + response `Parameters` instances showing the full interaction shape

## Test plan

- [x] `npx fsh-sushi .` — 0 errors, 0 warnings (35 profiles, 21 extensions, 19 ValueSets, 17 CodeSystems, 94 instances)
- [ ] Run `./_genonce.sh` and verify rendered HTML for `StructureDefinition-form-provenance`, `CodeSystem-form-activity`, and `OperationDefinition-tiro-populate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)