### PR TITLE
feat(ig): wire up openEHR archetype (ADL) rendering support

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -27,6 +27,11 @@ publisher:
 dependencies:
   hl7.fhir.uv.sdc: 4.0.0-ballot
   hl7.fhir.uv.extensions.r5: 5.2.0
+  openehr.base:
+    id: openehr
+    uri: http://openehr.org/fhir/ImplementationGuide/openehr.base
+    version: 0.1.0-snapshot
+    reason: Used to render openEHR archetypes (ADL) alongside FHIR profiles in this IG.
 #   hl7.fhir.us.core: 3.1.0
 #   hl7.fhir.us.mcode:
 #     id: mcode
@@ -67,6 +72,9 @@ dependencies:
 parameters:
   allow-extensible-warnings: true
   validation: [allow-any-extensions]
+  openehr: true
+  path-resource:
+    - input/archetypes
 # parameters:
 #   excludettl: true
 #   validation: [allow-any-extensions, no-broken-links]


### PR DESCRIPTION
## Summary

- Add `openehr.base#0.1.0-snapshot` as an IG dependency
- Enable IG Publisher openEHR mode (`openehr: true`) and point `path-resource` at a new `input/archetypes/` directory
- Mirrors the pattern used by the [HL7 Symptoms IG](https://build.fhir.org/ig/HL7/fhir-symptoms-ig/) — drop ADL 1.4 files into `input/archetypes/` and the IG Publisher will render them as `StructureDefinition-<archetype-id>.html` pages alongside our FHIR profiles

The `openehr.base` package is the official openEHR Reference Model published as a FHIR R5 IG (canonical `http://openehr.org/fhir/ImplementationGuide/openehr.base`), which is what enables the IG Publisher to validate and render archetypes.

## Test plan

- [x] `npx fsh-sushi .` → 0 errors, 0 warnings; `openehr.base#0.1.0-snapshot` resolves and loads 224 resources
- [ ] Drop a real ADL into `input/archetypes/` (e.g. from [CKM](https://ckm.openehr.org)) and run `./_genonce.sh` to confirm the generated `StructureDefinition-*.html` page renders
- [ ] Verify CI build (`_genonce.sh`) succeeds with the new dependency

## Follow-ups (not in this PR)

- Add Tiro-specific archetypes to `input/archetypes/`
- Add a `pagecontent` page positioning archetypes as informative clinical references alongside Tiro logical models (the Symptoms IG `profile.md` pattern)
- Add FSH `Mapping:` resources from logical models → FHIR profiles for archetype-aligned concepts

🤖 Generated with [Claude Code](https://claude.com/claude-code)