### PR TITLE
feat(ig): add openEHR lab archetypes + LabResult Observation profile

### DIFF
--- a/ig-tiro-template/layouts/layout-profile.html
+++ b/ig-tiro-template/layouts/layout-profile.html
@@ -1,0 +1,328 @@
+---
+---
+<!-- get modelType -->
+{% include fragment-modelType.html id='{{[id]}}' %}
+
+{% include fragment-pagebegin.html %}
+<div class="col-12">
+  <!--ReleaseHeader--><p id="publish-box">Publish Box goes here</p><!--EndReleaseHeader-->
+  {% include fragment-profile-navtabs.html type='{{[type]}}' id='{{[id]}}' active='content' %}
+
+  <a name="root"> </a>
+  <h2 id="root">{{modelType}}:
+{% if site.data.structuredefinitions["{{[id]}}"].abstract == true %}
+    <i>{{site.data.pages[page.path].title | escape_once}}</i>
+{% else %}
+    {{site.data.pages[page.path].title}}
+{% endif %}
+{% if site.data.resources[resource_].experimental == true or site.data.structuredefinitions["{{[id]}}"].abstract == true %}({% endif %}
+{% if site.data.structuredefinitions["{{[id]}}"].abstract == true %}Abstract{% endif %}
+{% if site.data.resources[resource_].experimental == true %}Experimental{% endif %}
+{% if site.data.resources[resource_].experimental == true or site.data.structuredefinitions["{{[id]}}"].abstract == true %}){% endif %}
+  </h2>
+
+{% include fragment-resourceTable.html %}
+{%if site.data.resources[resource_].description %}
+<p>
+{{site.data.resources[resource_].description|markdownify}}
+</p>
+{% endif %}{%if site.data.resources[resource_].purpose %}
+<p>
+{{site.data.resources[resource_].purpose|markdownify}}
+</p>
+{% endif %}
+
+
+<!-- insert intro if present -->
+{% include fragment-intro.html type='{{[type]}}' id='{{[id]}}' %}
+
+{%include StructureDefinition-{{[id]}}-sd-xref.xhtml%}
+
+  <!-- no uri -->
+  <a name="profile"> </a>
+  <h3 id="profile">Formal Views of Profile Content</h3>
+  <p>
+    <a href="http://build.fhir.org/ig/FHIR/ig-guidance/readingIgs.html#structure-definitions">Description of Profiles, Differentials, Snapshots and how the different presentations work</a>.
+  </p>
+  <div id="tabs">
+    <ul>
+      <li>
+        <a href="#tabs-key">Key Elements Table</a>
+      </li>
+      <li>
+        <a href="#tabs-diff">Differential Table</a>
+      </li>
+      <li>
+        <a href="#tabs-snap">Snapshot Table</a>
+      </li>
+{% if site.data.structuredefinitions["{{[id]}}"].adl %}
+      <li>
+        <a href="#tabs-openehr">openEHR View</a>
+      </li>
+      <li>
+        <a href="#tabs-adl">ADL</a>
+      </li>
+{% endif %}
+{% unless excludexml == 'y' %}
+<!--      <li>
+        <a href="#tabs-xml">Pseudo-XML</a>
+      </li>-->
+{% endunless %}
+{% unless excludejson == 'y' %}
+<!--      <li>
+        <a href="#tabs-json">Pseudo-JSON</a>
+      </li>-->
+{% endunless %}
+{% unless excludettl == 'y' %}
+      <!--<li>
+        <a href="#tabs-ttl">Pseudo-TTL</a>
+      </li>-->
+{% endunless %}
+      <li>
+        <a href="#tabs-summ">Statistics/References</a>
+      </li>
+      <li>
+        <a href="#tabs-all">All</a>
+      </li>
+    </ul>
+    <a name="tabs-key"> </a>
+    <div id="tabs-key">
+      <div id="tbl-key">
+        <div id="tbl-key-inner">
+          {%include StructureDefinition-{{[id]}}-snapshot-by-key.xhtml%}
+          <!--Terminology Bindings heading in the fragment -->
+          {%include StructureDefinition-{{[id]}}-tx-key.xhtml%}
+        
+          {% capture invariantskey %}
+            {% include StructureDefinition-{{[id]}}-inv-key.xhtml %}
+          {% endcapture %}
+          <!-- 218 is size of empty table -->
+          {% unless invariantskey.size <= 218 %}
+            <a name="inv-key"> </a>
+            <!--Constraints  heading in the fragment -->
+            {% include StructureDefinition-{{[id]}}-inv-key.xhtml %}
+          {% endunless%}
+        </div>
+      </div>
+    </div>
+    <a name="tabs-diff"> </a>
+    <div id="tabs-diff">
+      <div id="tbl-diff">
+        <p>This structure is derived from <a href="{{site.data.structuredefinitions['{{[id]}}'].basepath}}">{{site.data.structuredefinitions['{{[id]}}'].basename}}</a>
+        </p>
+        <div id="tbl-diff-inner">
+          {%include StructureDefinition-{{[id]}}-diff.xhtml%}
+          <a name="tx"> </a>
+          <!--Terminology Bindings heading in the fragment -->
+          {%include StructureDefinition-{{[id]}}-tx-diff.xhtml%}
+        
+          {% capture invariantsdiff %}
+            {% include StructureDefinition-{{[id]}}-inv-diff.xhtml %}
+          {% endcapture %}
+          <!-- 218 is size of empty table -->
+          {% unless invariantsdiff.size <= 218 %}
+            <a name="inv-diff"> </a>
+            <!--Constraints  heading in the fragment -->
+            {% include StructureDefinition-{{[id]}}-inv-diff.xhtml %}
+          {% endunless%}
+        </div>
+      </div>
+    </div>
+    <a name="tabs-snap"> </a>
+    <div id="tabs-snap">
+      <div id="tbl-snap">
+        <div id="tbl-snap-inner">
+          {%include StructureDefinition-{{[id]}}-snapshot.xhtml%}
+          <!--Terminology Bindings heading in the fragment -->
+          {%include StructureDefinition-{{[id]}}-tx.xhtml%}
+
+          {% capture invariants %}
+            {% include StructureDefinition-{{[id]}}-inv.xhtml %}
+          {% endcapture %}
+          <!-- 218 is size of empty table -->
+          {% unless invariants.size <= 218 %}
+            <a name="inv-snap"> </a>
+            <!--Constraints  heading in the fragment -->
+            {% include StructureDefinition-{{[id]}}-inv.xhtml %}
+          {% endunless%}
+        </div>
+      </div>
+    </div>
+{% if site.data.structuredefinitions["{{[id]}}"].adl %}
+    <a name="tabs-openehr"> </a>
+    <div id="tabs-openehr">
+      <div id="openehr">
+        <div id="openehr-inner">
+          {% include StructureDefinition-{{[id]}}-eview.xhtml %}
+        </div>
+      </div>
+    </div>
+    <a name="tabs-adl"> </a>
+    <div id="tabs-adl">
+      <div id="adl">
+        <div id="adl-inner">
+          {% include StructureDefinition-{{[id]}}-adl.xhtml %}
+        </div>
+      </div>
+    </div>
+{% endif %}
+{% unless excludexml == 'y' %}
+<!--    <a name="tabs-xml"> </a>
+    <div id="tabs-xml">
+      <div id="xml">
+        <div id="xml-inner">
+          {%include StructureDefinition-{{[id]}}-pseudo-xml.xhtml%}
+        </div>
+      </div>
+    </div>-->
+{% endunless %}
+{% unless excludejson == 'y' %}
+<!--    <a name="tabs-json"> </a>
+    <div id="tabs-json">
+      <div id="json">
+        <div id="json-inner">
+          {%include StructureDefinition-{{[id]}}-pseudo-json.xhtml%}
+        </div>
+      </div>
+    </div>-->
+{% endunless %}
+{% unless excludettl == 'y' %}
+    <!--<a name="tabs-ttl"> </a>
+    <div id="tabs-ttl">
+      <div id="ttl">
+        <div id="ttl-inner">
+          {%include StructureDefinition-{{[id]}}-pseudo-ttl.xhtml%}
+        </div>
+      </div>
+    </div>-->
+{% endunless %}
+    <a name="tabs-summ"> </a>
+    <div id="tabs-summ">
+      <div id="tbl-summ">
+        <p>This structure is derived from <a href="{{site.data.structuredefinitions['{{[id]}}'].basepath}}">{{site.data.structuredefinitions['{{[id]}}'].basename}}</a>
+        </p>
+        <div id="tbl-summ-inner">
+          <a name="summary"> </a>
+          {%include StructureDefinition-{{[id]}}-summary.xhtml%}
+        </div>
+      </div>
+    </div>
+    <a name="tabs-all"> </a>
+    <div id="tabs-all">
+      <div id="all-tbl-key">
+        <p>
+          <b>Key Elements View</b>
+        </p>
+        <div id="all-tbl-key-inner">
+          {%include StructureDefinition-{{[id]}}-snapshot-by-key-all.xhtml%}
+          <!--Terminology Bindings heading in the fragment -->
+          {%include StructureDefinition-{{[id]}}-tx-key.xhtml%}
+        
+          {% capture invariantskey %}
+            {% include StructureDefinition-{{[id]}}-inv-key.xhtml %}
+          {% endcapture %}
+          <!-- 218 is size of empty table -->
+          {% unless invariantskey.size <= 218 %}
+            <a name="inv-all-key"> </a>
+            <!--Constraints  heading in the fragment -->
+            {% include StructureDefinition-{{[id]}}-inv-key.xhtml %}
+          {% endunless%}
+        </div>
+      </div>
+      <div id="all-tbl-diff">
+        <p>
+          <b>Differential View</b>
+        </p>
+        <p>This structure is derived from <a href="{{site.data.structuredefinitions['{{[id]}}'].basepath}}">{{site.data.structuredefinitions['{{[id]}}'].basename}}</a>
+        </p>
+        <div id="all-tbl-diff-inner">
+          {%include StructureDefinition-{{[id]}}-diff-all.xhtml%}
+          <!--Terminology Bindings heading in the fragment -->
+          {%include StructureDefinition-{{[id]}}-tx-diff.xhtml%}
+        
+          {% capture invariantsdiff %}
+            {% include StructureDefinition-{{[id]}}-inv-diff.xhtml %}
+          {% endcapture %}
+          <!-- 218 is size of empty table -->
+          {% unless invariantsdiff.size <= 218 %}
+            <a name="inv-all-diff"> </a>
+            <!--Constraints  heading in the fragment -->
+            {% include StructureDefinition-{{[id]}}-inv-diff.xhtml %}
+          {% endunless%}
+        </div>
+      </div>
+      <div id="all-tbl-snap">
+        <p>
+          <b>Snapshot View</b>
+        </p>
+        <div id="all-tbl-snap-inner">
+          {%include StructureDefinition-{{[id]}}-snapshot-all.xhtml%}
+          <!--Terminology Bindings heading in the fragment -->
+          {%include StructureDefinition-{{[id]}}-tx.xhtml%}
+        
+          {% capture invariants %}
+            {% include StructureDefinition-{{[id]}}-inv.xhtml %}
+          {% endcapture %}
+          <!-- 218 is size of empty table -->
+          {% unless invariants.size <= 218 %}
+            <a name="inv-all-snap"> </a>
+            <!--Constraints  heading in the fragment -->
+            {% include StructureDefinition-{{[id]}}-inv.xhtml %}
+          {% endunless%}
+        </div>
+      </div>
+{% unless excludexml == 'y' %}
+      <!--<div id="all-xml">
+        <p>
+          <b>XML Template</b>
+        </p>
+        <div id="all-xml-inner">
+          {%include StructureDefinition-{{[id]}}-pseudo-xml.xhtml%}
+        </div>
+      </div>-->
+{% endunless %}
+{% unless excludejson == 'y' %}
+      <!--<div id="all-json">
+        <p>
+          <b>JSON Template</b>
+        </p>
+        <div id="all-json-inner">
+          {%include StructureDefinition-{{[id]}}-pseudo-json.xhtml%}
+        </div>
+      </div>-->
+{% endunless %}
+{% unless excludettl == 'y' %}
+      <!--<div id="all-ttl">
+        <p>
+          <b>TTL Template</b>
+        </p>
+        <div id="all-ttl-inner">
+          {%include StructureDefinition-{{[id]}}-pseudo-ttl.xhtml%}
+        </div>
+      </div>-->
+{% endunless %}
+      <div id="all-summ">
+        <p>This structure is derived from <a href="{{site.data.structuredefinitions['{{[id]}}'].basepath}}">{{site.data.structuredefinitions['{{[id]}}'].basename}}</a>
+        </p>
+        <div id="all-summ-inner">
+          {%include StructureDefinition-{{[id]}}-summary-all.xhtml%}
+        </div>
+      </div>
+    </div>
+  </div>
+  <p>&#160;</p>
+  <p>Other representations of profile: <a href="{{[type]}}-{{[id]}}.csv">CSV</a>, <a href="{{[type]}}-{{[id]}}.xlsx">Excel</a>{% unless modelType == 'Logical Model' %}, <a href="{{[type]}}-{{[id]}}.sch">Schematron</a>
+{% endunless %} 
+  </p>
+
+  {% if site.data.resources[resource_].contained != nil %}
+  <h4>Contained resources</h4>
+  {% include {{[type]}}-{{[id]}}-contained-index.xhtml %}
+  {% endif %}
+
+<!-- insert notes if present -->
+{% include fragment-notes.html type='{{[type]}}' id='{{[id]}}' %}
+
+</div>
+{% assign includetabscripts = 'true' %}
+{% include fragment-pageend.html %}

--- a/input/archetypes/openEHR-EHR-CLUSTER.laboratory_test_analyte.v1.adl
+++ b/input/archetypes/openEHR-EHR-CLUSTER.laboratory_test_analyte.v1.adl
@@ -1,0 +1,1407 @@
+﻿archetype (adl_version=1.4; rm_release=1.1.0; uid=f86cd61b-0e0e-4a18-8c07-9c4e537bb4e4)
+	openEHR-EHR-CLUSTER.laboratory_test_analyte.v1
+
+concept
+	[at0000]	-- Laboratory analyte result
+language
+	original_language = <[ISO_639-1::en]>
+	translations = <
+		["de"] = <
+			language = <[ISO_639-1::de]>
+			author = <
+				["name"] = <"Michael Lieser, Antje Wulff, Natalia Strauch, Alina Rehberg">
+				["organisation"] = <"Department of Infectious Diseases, Heidelberg University Hospital, Medizinische Hochschule Hannover">
+				["email"] = <"michael.lieser@med.uni-heidelberg.de, wulff.antje@mh-hannover.de, Strauch.Natalia@mh-hannover.de, rehberg.alina@mh-hannover.de">
+			>
+		>
+		["sv"] = <
+			language = <[ISO_639-1::sv]>
+			author = <
+				["name"] = <"Linda Aulin, Linda Aulin Lundeqvist">
+				["organisation"] = <"Region Stockholm, Karolinska University Hospital, Karolinska University Hospital, Region Stockholm">
+				["email"] = <"linda.aulin@sll.se, linda.aulin-lundeqvist@regionstockholm.se">
+			>
+		>
+		["nb"] = <
+			language = <[ISO_639-1::nb]>
+			author = <
+				["name"] = <"Silje Ljosland Bakke, Liv Laugen">
+				["organisation"] = <"Nasjonal IKT HF, ​Oslo University Hospital, Norway">
+				["email"] = <"liv.laugen@ous-hf.no">
+			>
+		>
+		["pt-br"] = <
+			language = <[ISO_639-1::pt-br]>
+			author = <
+				["name"] = <"Adriana Kitajima, Débora Farage, Fernanda Maia, Laíse Figueiredo, Marivan Abrahão">
+				["organisation"] = <"Core Consulting">
+				["email"] = <"contato@coreconsulting.com.br">
+			>
+			accreditation = <"Hospital Alemão Oswaldo Cruz (HAOC)">
+		>
+		["zh-cn"] = <
+			language = <[ISO_639-1::zh-cn]>
+			author = <
+				["name"] = <"Lin Zhang">
+				["organisation"] = <"Freelancer">
+				["email"] = <"linforest@163.com">
+			>
+		>
+		["nl"] = <
+			language = <[ISO_639-1::nl]>
+			author = <
+				["name"] = <"Joost Holslag">
+				["organisation"] = <"Nedap">
+				["email"] = <"joost.holslag@nedap.com">
+			>
+			accreditation = <"MD">
+		>
+		["es"] = <
+			language = <[ISO_639-1::es]>
+			author = <
+				["name"] = <"Julio de Sosa">
+				["organisation"] = <"Servei Català de la Salut">
+				["email"] = <"juliodesosa@catsalut.cat">
+			>
+		>
+		["ca"] = <
+			language = <[ISO_639-1::ca]>
+			author = <
+				["name"] = <"Manuel José Zafra Doménech">
+				["organisation"] = <"TRADCREA, S.L.">
+				["email"] = <"mzafra@tradcrea.com">
+			>
+			other_details = <
+				["other_contributors"] = <"Servei Català de la Salut">
+			>
+		>
+	>
+description
+	original_author = <
+		["name"] = <"Ian McNicoll">
+		["organisation"] = <"freshEHR Clinical Informatics, UK">
+		["email"] = <"ian@freshehr.com">
+		["date"] = <"2015-07-20">
+	>
+	details = <
+		["de"] = <
+			language = <[ISO_639-1::de]>
+			purpose = <"Dient der Darstellung von einzelnen Ergebniswerten für Labor-Analyten, die in der klinischen Diagnostikanalyse wie medizinische Biochemie, Hämatologie, Immunologie und Transfusionsmedizin zu finden ist.">
+			use = <"Dient zur Erfassung von einzelnen Ergebniswerten für Labor-Analyten, die in der klinischen Diagnostik verbreitet sind, wie z. B. biochemische, hämatologische, immunologische und transfusionsmedizinische Tests. Diese Ergebnisse können auch in Berichten zur anatomischen Pathologie als \"zusätzliche Untersuchungen\" vorkommen, zum Beispiel Durchflusszytometrie.
+
+Eine oder mehrere Instanzen dieses Archetyps können im SLOT \"Testergebnis\" des Archetyps OBSERVATION.laboratory_test_result verschachtelt werden.
+
+Unter Umständen kann dieser Archetyp in einem CLUSTER.laboratory_test_panel Archetyp verwendet werden - zusammen mit andere Analyten, die normalerweise als Teil eine Panels oder Profils getestet und/oder befundet werden.
+
+Dieser Archetyp kann im Rahmen einer komplexerem Labor/Pathologie-Befundung, z.B. in anatomisch-pathologischen Befunden verwendet werden, in denen oft quantitative Resultate, wie Durchfluss-Zytometrie-Analysen neben den üblichen makroskopischen und mikroskopischen Ergebnissen dokumentiert werden.">
+			keywords = <"Labor", "Pathologie", "Analyt", "Bestandteil", "Ergebnis">
+			misuse = <"Nicht zur Darstellung von strukturierten Details von makroskopischen/mikroskopischen Befunden der anatomischen Pathologie verwenden.
+
+Nicht zur Darstellung von detaillierten, strukturierten Ergebnissen für Mikrobiologische Befunde verwenden.
+">
+		>
+		["sv"] = <
+			language = <[ISO_639-1::sv]>
+			purpose = <"Registrering av ett enskilt laboratorieanalysresultat som vanligtvis förekommer i undersökningar inom exempelvis klinisk kemi, kliniska mikrobiologi, klinisk genetik, immunologi och transfusionsmedicin.
+">
+			use = <"*Use to record a single value laboratory analyte result, commonly found in clinical pathology testing such as medical biochemistry, haematology, immunology and transfusion medicine. These results may also appear in anatomical pathology reports as ‘ancillary tests', for example flow cytometry.
+
+One or more instances of this archetype may be nested within the 'Test result' SLOT in the OBSERVATION.laboratory_test_result. 
+
+In some circumstances this archetype may be carried within a CLUSTER.laboratory_test_panel archetype, together with other analytes which are normally tested and/or reported as part of a battery, panel or profile. 
+
+This archetype may be used within the setting of more complex laboratory/pathology reporting such as anatomical pathology reports where quantitative results such as cytometric flow studies are often reported alongside conventional macroscopic and microscopic reporting. (en)">
+			keywords = <"laboratorium", "labb", "patologi", "analyt", "analys", "resultat", "analysresultat", "svar", "komponent">
+			misuse = <"*Not to be used to record structured details about anatomical pathology macroscopic/microscopic findings.
+
+Not to be used to record detailed structured results for microbiological culture findings. (en)">
+		>
+		["nb"] = <
+			language = <[ISO_639-1::nb]>
+			purpose = <"For å registrere ett enkelt laboratorieresultat innenfor områder som medisinsk biokjemi, hematologi, immunologi og transfusjonsmedisin.">
+			use = <"For å registrere ett enkelt laboratorieresultat innenfor områder som medisinsk biokjemi, hematologi, immunologi og transfusjonsmedisin. Arketypen kan også brukes til tilleggsundersøkelser innenfor patologi, for eksempel flowcytometri.
+
+En eller flere instanser av denne arketypen kan nøstes i SLOTet \"Undersøkelsesresultat\" i arketypen OBSERVATION.laboratory_test_result.
+
+I noen sammenhenger kan denne arketypen brukes i arketypen CLUSTER.laboratory_test_panel, sammen med andre analytter som vanligvis utføres sammen som del av en analysegruppe.
+
+Denne arketypen kan brukes innenfor mer komplekse laboratorie/patologirapporter der kvantitative svar som for eksempel flowcytometri rapporteres sammen med konvensjonelle makroskopiske og mikroskopiske undersøkelser.">
+			keywords = <"laboratorie", "analytt", "analyse", "svar", "resultat">
+			misuse = <"Skal ikke brukes til å registrere strukturerte detaljer om makroskopiske/mikroskopiske funn i anatomisk patologi.
+
+Skal ikke brukes til å registrere detaljerte strukturerte resultater for mikrobiologiske dyrkningsfunn.">
+			copyright = <"© openEHR Foundation">
+		>
+		["pt-br"] = <
+			language = <[ISO_639-1::pt-br]>
+			purpose = <"Para gravar valores únicos e individuais de resultados laboratoriais de analitos comuns a testes patológicos clínicos como bioquímica, hematologia e imunologia.
+">
+			use = <"*Use to record a single value laboratory analyte result, commonly found in clinical pathology testing such as medical biochemistry, haematology, immunology and transfusion medicine. These results may also appear in anatomical pathology reports as ‘ancillary tests', for example flow cytometry.
+
+One or more instances of this archetype may be nested within the 'Test result' SLOT in the OBSERVATION.laboratory_test_result. 
+
+In some circumstances this archetype may be carried within a CLUSTER.laboratory_test_panel archetype, together with other analytes which are normally tested and/or reported as part of a battery, panel or profile. 
+
+This archetype may be used within the setting of more complex laboratory/pathology reporting such as anatomical pathology reports where quantitative results such as cytometric flow studies are often reported alongside conventional macroscopic and microscopic reporting. (en)">
+			keywords = <"laboratório", "patologia", "analito", "componente", "resultado">
+			misuse = <"*Not to be used to record structured details about anatomical pathology macroscopic/microscopic findings.
+
+Not to be used to record detailed structured results for microbiological culture findings. (en)">
+		>
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"To record a single value laboratory analyte result, commonly found in clinical pathology testing such as medical biochemistry, haematology, immunology and transfusion medicine.">
+			use = <"Use to record a single value laboratory analyte result, commonly found in clinical pathology testing such as medical biochemistry, haematology, immunology and transfusion medicine. These results may also appear in anatomical pathology reports as ‘ancillary tests', for example flow cytometry.
+
+One or more instances of this archetype may be nested within the 'Test result' SLOT in the OBSERVATION.laboratory_test_result. 
+
+In some circumstances this archetype may be carried within a CLUSTER.laboratory_test_panel archetype, together with other analytes which are normally tested and/or reported as part of a battery, panel or profile. 
+
+This archetype may be used within the setting of more complex laboratory/pathology reporting such as anatomical pathology reports where quantitative results such as cytometric flow studies are often reported alongside conventional macroscopic and microscopic reporting.">
+			keywords = <"laboratory", "pathology", "analyte", "constituent", "result">
+			misuse = <"Not to be used to record structured details about anatomical pathology macroscopic/microscopic findings.
+
+Not to be used to record detailed structured results for microbiological culture findings.">
+			copyright = <"© openEHR Foundation">
+		>
+		["zh-cn"] = <
+			language = <[ISO_639-1::zh-cn]>
+			purpose = <"旨在用于记录单值型的实验室检验结果，常见于医学生物化学、血液学、免疫学和输血医学等临床病理学/检验医学检测当中。">
+			use = <"*Use to record a single value laboratory analyte result, commonly found in clinical pathology testing such as medical biochemistry, haematology, immunology and transfusion medicine. These results may also appear in anatomical pathology reports as ‘ancillary tests', for example flow cytometry.
+
+One or more instances of this archetype may be nested within the 'Test result' SLOT in the OBSERVATION.laboratory_test_result. 
+
+In some circumstances this archetype may be carried within a CLUSTER.laboratory_test_panel archetype, together with other analytes which are normally tested and/or reported as part of a battery, panel or profile. 
+
+This archetype may be used within the setting of more complex laboratory/pathology reporting such as anatomical pathology reports where quantitative results such as cytometric flow studies are often reported alongside conventional macroscopic and microscopic reporting. (en)">
+			keywords = <"实验室", "病理学", "检验医学", "检验", "分析物", "检验项目", "检验结果", "化验结果", "构成要素">
+			misuse = <"*Not to be used to record structured details about anatomical pathology macroscopic/microscopic findings.
+
+Not to be used to record detailed structured results for microbiological culture findings. (en)">
+		>
+		["nl"] = <
+			language = <[ISO_639-1::nl]>
+			purpose = <"Voor het vastleggen van een enkele laboratorium analyt uitslag, gebruikelijk in klinische chemische onderzoeken zoals medische biochemie, hematologie, immunologie en transfusiegeneeskunde.">
+			use = <"*Use to record a single value laboratory analyte result, commonly found in clinical pathology testing such as medical biochemistry, haematology, immunology and transfusion medicine. These results may also appear in anatomical pathology reports as ‘ancillary tests', for example flow cytometry.
+
+One or more instances of this archetype may be nested within the 'Test result' SLOT in the OBSERVATION.laboratory_test_result. 
+
+In some circumstances this archetype may be carried within a CLUSTER.laboratory_test_panel archetype, together with other analytes which are normally tested and/or reported as part of a battery, panel or profile. 
+
+This archetype may be used within the setting of more complex laboratory/pathology reporting such as anatomical pathology reports where quantitative results such as cytometric flow studies are often reported alongside conventional macroscopic and microscopic reporting. (en)">
+			keywords = <"laboratorium", "klinische chemie", "analyt", "bepaling", "uitslag">
+			misuse = <"*Not to be used to record structured details about anatomical pathology macroscopic/microscopic findings.
+
+Not to be used to record detailed structured results for microbiological culture findings. (en)">
+		>
+		["es"] = <
+			language = <[ISO_639-1::es]>
+			purpose = <"Registrar el resultado de un analito de laboratorio de valor único, normalmente en pruebas de patología clínica como bioquímica médica, hematología, inmunología y medicina transfusional.">
+			use = <"*Use to record a single value laboratory analyte result, commonly found in clinical pathology testing such as medical biochemistry, haematology, immunology and transfusion medicine. These results may also appear in anatomical pathology reports as ‘ancillary tests', for example flow cytometry.
+
+One or more instances of this archetype may be nested within the 'Test result' SLOT in the OBSERVATION.laboratory_test_result. 
+
+In some circumstances this archetype may be carried within a CLUSTER.laboratory_test_panel archetype, together with other analytes which are normally tested and/or reported as part of a battery, panel or profile. 
+
+This archetype may be used within the setting of more complex laboratory/pathology reporting such as anatomical pathology reports where quantitative results such as cytometric flow studies are often reported alongside conventional macroscopic and microscopic reporting. (en)">
+			keywords = <"laboratorio", "patología", "analito", "componente", "resultado">
+			misuse = <"*Not to be used to record structured details about anatomical pathology macroscopic/microscopic findings.
+
+Not to be used to record detailed structured results for microbiological culture findings. (en)">
+		>
+		["ca"] = <
+			language = <[ISO_639-1::ca]>
+			purpose = <"Registrar un resultat d'un anàlit de laboratori d'un únic valor, que es troba normalment en les proves de patologia clínica, com ara bioquímica, hematologia, immunologia, i medicina transfusional.">
+			use = <"*Use to record a single value laboratory analyte result, commonly found in clinical pathology testing such as medical biochemistry, haematology, immunology and transfusion medicine. These results may also appear in anatomical pathology reports as ‘ancillary tests', for example flow cytometry.
+
+One or more instances of this archetype may be nested within the 'Test result' SLOT in the OBSERVATION.laboratory_test_result. 
+
+In some circumstances this archetype may be carried within a CLUSTER.laboratory_test_panel archetype, together with other analytes which are normally tested and/or reported as part of a battery, panel or profile. 
+
+This archetype may be used within the setting of more complex laboratory/pathology reporting such as anatomical pathology reports where quantitative results such as cytometric flow studies are often reported alongside conventional macroscopic and microscopic reporting. (en)">
+			keywords = <"laboratori", "patologia", "anàlit", "constituent", "resultat">
+			misuse = <"*Not to be used to record structured details about anatomical pathology macroscopic/microscopic findings.
+
+Not to be used to record detailed structured results for microbiological culture findings. (en)">
+		>
+	>
+	lifecycle_state = <"published">
+	other_contributors = <"Vebjørn Arntzen, Oslo University Hospital, Norway (openEHR Editor)", "Heidi Aursand, Oslo universitetssykehus, Norway", "Silje Ljosland Bakke, Nasjonal IKT HF, Norway (openEHR Editor)", "SB Bhattacharyya, Sudisa Consultancy Services, India", "Fatemeh Chalabianloo, Helse Bergen, Norway", "Anca Heyd, DIPS ASA, Norway", "Evelyn Hovenga, EJSH Consulting, Australia", "Nasjonal IKT, Norway", "Silje Kaada, Helse-Bergen, Avdeling for immunologi og transfusjonsmedisin, Norway", "Lars Morgan Karlsen, DIPS ASA, Norway", "Nils Kolstrup, Skansen Legekontor og Nasjonalt Senter for samhandling og telemedisin, Norway", "Liv Laugen, Oslo universitetssykehus, Norway", "Heather Leslie, Atomica Informatics, Australia (openEHR Editor)", "Ole Martin Sand, DIPS ASA, Norway", "Ian McNicoll, freshEHR Clinical Informatics, United Kingdom (openEHR Editor)", "Paul Miller, SCIMP NHS Scotland, United Kingdom", "Andrej Orel, Marand d.o.o., Slovenia", "Jussara Rotzsch, Hospital Alemão Oswaldo Cruz, Brazil", "Norwegian Review Summary, Nasjonal IKT HF, Norway", "Line Sæle, Nasjonal IKT HF, Norway", "Nyree Taylor, Ocean Informatics, Australia", "John Tore Valand, Helse Bergen, Norway (openEHR Editor)", "Wouter Zanen, Eurotranplant, Netherlands", "Lin Zhang, Taikang Insurance Group, China">
+	other_details = <
+		["licence"] = <"This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/.">
+		["custodian_organisation"] = <"openEHR Foundation">
+		["references"] = <"Pathology Test Result, Draft Archetype [Internet]. Australian Digital Health Agency, Australian Digital Health Agency Clinical Knowledge Manager [cited: 2017-06-27]. No longer available.
+
+Pathology (Data Specifications) Version 1.0 [Internet]. Sydney, Australia: National E-Health Transition Authority; 2007 May 29 [cited 2011 Jul 11]; No longer available.
+
+Laboratory Technical Framework, Volume 3: Content, Revision 3.0 [Internet]. USA: IHE International; 2011 May 19; [cited 2011 Jul 11]. Available from: https://www.ihe.net/Technical_Framework/upload/IHE_Lab_TF_Rev3-0_Vol3_FT_2011-05-19.pdf
+
+HL7 FHIR Resource - Observation V1.8.0 FHIR STU3 [Internet]. Health Level Seven International; [accessed 2017 Jun 27]. Available from: http://hl7.org/fhir/2017Jan/.">
+		["original_namespace"] = <"org.openehr">
+		["original_publisher"] = <"openEHR Foundation">
+		["custodian_namespace"] = <"org.openehr">
+		["MD5-CAM-1.0.1"] = <"5E85E26C754037F9839ADADAB5F76EF2">
+		["build_uid"] = <"4b21a6cd-1731-4be4-9355-6acd97563678">
+		["revision"] = <"1.2.1">
+	>
+
+definition
+	CLUSTER[at0000] matches {    -- Laboratory analyte result
+		items cardinality matches {1..*; unordered} matches {
+			ELEMENT[at0027] occurrences matches {0..1} matches {    -- Analyte result sequence
+				value matches {
+					DV_COUNT matches {*}
+				}
+			}
+			ELEMENT[at0024] occurrences matches {0..1} matches {    -- Analyte name
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			ELEMENT[at0001] occurrences matches {0..*} matches {*}    -- Analyte result
+			allow_archetype CLUSTER[at0014] occurrences matches {0..*} matches {    -- Analyte result detail
+				include
+					archetype_id/value matches {/.*/}
+			}
+			ELEMENT[at0004] occurrences matches {0..1} matches {    -- Reference range guidance
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			ELEMENT[at0028] occurrences matches {0..1} matches {*}    -- Test method
+			ELEMENT[at0031] occurrences matches {0..1} matches {    -- Analysis performed time
+				value matches {
+					DV_DATE_TIME matches {*}
+				}
+			}
+			ELEMENT[at0025] occurrences matches {0..1} matches {    -- Validation time
+				value matches {
+					DV_DATE_TIME matches {*}
+				}
+			}
+			ELEMENT[at0005] occurrences matches {0..*} matches {    -- Result status
+				value matches {
+					DV_CODED_TEXT matches {
+						defining_code matches {
+							[local::
+							at0015,    -- Registered
+							at0016,    -- Partial
+							at0017,    -- Preliminary
+							at0018,    -- Final
+							at0020,    -- Amended
+							at0019,    -- Corrected
+							at0021,    -- Appended
+							at0023,    -- Cancelled
+							at0022]    -- Entered in error
+						}
+					}
+					DV_TEXT matches {*}
+				}
+			}
+			ELEMENT[at0006] occurrences matches {0..1} matches {    -- Result status time
+				value matches {
+					DV_DATE_TIME matches {*}
+				}
+			}
+			ELEMENT[at0026] occurrences matches {0..1} matches {    -- Specimen
+				value matches {
+					DV_IDENTIFIER matches {*}
+					DV_URI matches {*}
+					DV_TEXT matches {*}
+				}
+			}
+			ELEMENT[at0032] occurrences matches {0..1} matches {    -- Accredited
+				value matches {
+					DV_BOOLEAN matches {*}
+					DV_TEXT matches {*}
+				}
+			}
+			ELEMENT[at0003] occurrences matches {0..*} matches {    -- Comment
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+		}
+	}
+
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Laboratory analyte result">
+					description = <"The result of a laboratory test for a single analyte value.">
+				>
+				["at0001"] = <
+					text = <"Analyte result">
+					description = <"The value of the analyte result.">
+					comment = <"For example '7.3 mmol/l', 'Raised'. The 'Any' data type will need to be constrained to an appropriate data type in a specialisation, a template or at run-time to reflect the actual analyte result. The Quantity data type has reference model attributes that include flags for normal/abnormal, reference ranges and approximations - see https://specifications.openehr.org/releases/RM/latest/data_types.html#_dv_quantity_class for more details.">
+					hl7v2_mapping = <"OBX.2, OBX.5, OBX.6, OBX.7, OBX.8">
+					fhir_mapping = <"Observation.value[x]">
+				>
+				["at0003"] = <
+					text = <"Comment">
+					description = <"Additional narrative about the analyte result, not captured in other fields.">
+					hl7v2_mapping = <"NTE.3">
+					fhir_mapping = <"Observation.note">
+				>
+				["at0004"] = <
+					text = <"Reference range guidance">
+					description = <"Additional advice on the applicability of the reference range to this result or may carry text or coded textual guidance as to whether the result is within the normal range.">
+					comment = <"For example, 'within normal limits for age and sex'.">
+				>
+				["at0005"] = <
+					text = <"Result status">
+					description = <"The status of the analyte result value.">
+					comment = <"The values have been specifically chosen to match those in the HL7 FHIR Diagnostic report, historically derived from HL7v2 practice. Other local codes/terms can be used via the Text 'choice'.
+
+This element allows multiple occurrences to support use cases where more than one type of status need to be implemented.">
+					hl7v2_mapping = <"OBX.11">
+					fhir_mapping = <"Observation.status">
+				>
+				["at0006"] = <
+					text = <"Result status time">
+					description = <"The date and time that the analyte result was issued for the recorded ‘Result status’.">
+					hl7v2_mapping = <"OBX.19">
+					fhir_mapping = <"Observation.issued">
+				>
+				["at0014"] = <
+					text = <"Analyte result detail">
+					description = <"Further detail regarding an individual result.">
+				>
+				["at0015"] = <
+					text = <"Registered">
+					description = <"The existence of the test is registered in the Laboratory Information System, but there is nothing yet available.">
+				>
+				["at0016"] = <
+					text = <"Partial">
+					description = <"This is a partial (e.g. initial, interim or preliminary) Test Result: data in the Test Result may be incomplete or unverified.">
+				>
+				["at0017"] = <
+					text = <"Preliminary">
+					description = <"Verified early results are available, but not all results are final. This is a sub-category of 'Partial'.">
+				>
+				["at0018"] = <
+					text = <"Final">
+					description = <"The Test result is complete and verified by an authorised person.">
+				>
+				["at0019"] = <
+					text = <"Corrected">
+					description = <"The result has been modified subsequent to being Final, and is complete and verified by an authorised person. This is a sub-category of 'Amended'.">
+				>
+				["at0020"] = <
+					text = <"Amended">
+					description = <"The result has been modified subsequent to being Final, and is complete and verified by an authorised person, and result data has been changed.">
+				>
+				["at0021"] = <
+					text = <"Appended">
+					description = <"Subsequent to being final, the report has been modified by adding new content. The existing content is unchanged. This is a sub-category of 'Amended'.">
+				>
+				["at0022"] = <
+					text = <"Entered in error">
+					description = <"The Test Result has been withdrawn following previous Final release.">
+				>
+				["at0023"] = <
+					text = <"Cancelled">
+					description = <"The result is unavailable because the test was not started or not completed (also sometimes called 'aborted').">
+				>
+				["at0024"] = <
+					text = <"Analyte name">
+					description = <"The name of the analyte result.">
+					comment = <"The value for this element is normally supplied in a specialisation, in a template or at run-time to reflect the actual analyte. For example: 'Serum sodium', 'Haemoglobin'. Coding with an external terminology is strongly recommended, such as LOINC, NPU, SNOMED CT, or local lab terminologies.">
+					hl7v2_mapping = <"OBX.3">
+					fhir_mapping = <"Observation.code">
+				>
+				["at0025"] = <
+					text = <"Validation time">
+					description = <"The date and time that the analyte result was validated in the laboratory by a healthcare practitioner.">
+					comment = <"In many jurisdictions the 'Result status' is assumed to include medical validation i.e. a 'final' result will be assumed to be medically validated, but in others this will be recorded and reported separately using this data element.">
+				>
+				["at0026"] = <
+					text = <"Specimen">
+					description = <"Identification of the specimen used for the analyte result.">
+					comment = <"In some situations, a single Laboratory test result archetype will contain multiple Specimen archetypes and multiple Analyte result archetypes. In these situations, this 'Specimen' data element is needed to be able to connect the results with the correct specimens.">
+				>
+				["at0027"] = <
+					text = <"Analyte result sequence">
+					description = <"The intended position of this analyte result within the overall sequence of analyte results.">
+					comment = <"For example: '1' '2', '3'. Where multiple analyte results are reported, the 'Analyte result sequence' makes the order in which they were reported explicit.">
+				>
+				["at0028"] = <
+					text = <"Test method">
+					description = <"Description about the method used to perform the test on this analyte only.">
+					comment = <"If the test method applies to an entire panel, the test method can be captured using the 'Test method' data element within the OBSERVATION.laboratory_test_result">
+				>
+				["at0031"] = <
+					text = <"Analysis performed time">
+					description = <"The date and time when the analyte result was performed in the laboratory by a healthcare practitioner.">
+					comment = <"Represents the actual analysis timestamp, independent of when the result is recorded or reported.">
+				>
+				["at0032"] = <
+					text = <"Accredited">
+					description = <"Indicates whether the analytical method used for this analyte is accredited.">
+					comment = <"Supports quality assurance and regulatory compliance by specifying whether the laboratory analysis was performed under an accredited method.">
+				>
+			>
+		>
+		["nb"] = <
+			items = <
+				["at0000"] = <
+					text = <"Analyseresultat">
+					description = <"Resultatet av en individuell laboratorieanalyse.">
+				>
+				["at0001"] = <
+					text = <"Analyseresultat">
+					description = <"Verdien av analyseresultatet.">
+					comment = <"For eksempel \"7,3 mmol/L\" eller \"Forhøyet\". Datatypen \"Udefinert datatype\" må begrenses til en passende datatype i en spesialisering, et templat eller i applikasjonen. Datatypen Quantity har attributter fra referansemodellen som dekker flagg for normalt/unormalt, referanseområder og approksimeringer. Se https://specifications.openehr.org/releases/RM/latest/data_types.html#_dv_quantity_class for mer detaljer.">
+					hl7v2_mapping = <"OBX.2, OBX.5, OBX.6, OBX.7, OBX.8">
+					fhir_mapping = <"Observation.value[x]">
+				>
+				["at0003"] = <
+					text = <"Kommentar">
+					description = <"Ytterligere fritekst om analyseresultatet som ikke fanges opp av andre elementer.">
+					hl7v2_mapping = <"NTE.3">
+					fhir_mapping = <"Observation.note">
+				>
+				["at0004"] = <
+					text = <"Veileder for referanseområde">
+					description = <"Veileder for å finne ut om referanseverdien er relevant for dette resultatet. Kan inneholde tekst eller kodet tekstlig råd for om resultatet ligger innenfor normalområdet.">
+					comment = <"For eksempel \"innenfor normale grenseverdier i forhold til alder og kjønn\".">
+				>
+				["at0005"] = <
+					text = <"Resultatstatus">
+					description = <"Status for analyseresultatet.">
+					comment = <"Verdiene er valgt spesifikt for å samsvare med verdiene i HL7 FHIR-ressursen \"Diagnostic report\", som historisk sett kommer fra praksis i HL7 v2. Andre lokale koder eller termer kan brukes ved å bruke datatypen \"Fri eller kodet tekst\".
+
+Dette elementet kan repeteres for å imøtekomme brukstilfeller der det er mer enn en type status som må implementeres.">
+					hl7v2_mapping = <"OBX.11">
+					fhir_mapping = <"Observation.status">
+				>
+				["at0006"] = <
+					text = <"Tidspunkt for statusendring">
+					description = <"Datoen og tidspunktet da analyseresultatet ble utstedt for den aktuelle \"Analyseresultatstatus\".">
+					hl7v2_mapping = <"OBX.19">
+					fhir_mapping = <"Observation.issued">
+				>
+				["at0014"] = <
+					text = <"Detaljer om analyseresultat">
+					description = <"Ytterligere detaljer knyttet til et enkelt analyseresultat.">
+				>
+				["at0015"] = <
+					text = <"Registrert">
+					description = <"Analysen er registrert i laboratoriesystemet, men resultatet er ikke tilgjengelig per nå.">
+				>
+				["at0016"] = <
+					text = <"Ufullstendig">
+					description = <"Dette er et delvis (dvs initalt, foreløpig eller preliminært) svar: Data i resultatet kan være ukomplett eller ubekreftet.">
+				>
+				["at0017"] = <
+					text = <"Foreløpig">
+					description = <"Verifiserte tidlige resultater er tilgjengelige, men ikke alle resultater er endelige. Dette er en underkategori av \"Delvis\".">
+				>
+				["at0018"] = <
+					text = <"Endelig">
+					description = <"Resultatet er komplett og er bekreftet av ansvarlig person.">
+				>
+				["at0019"] = <
+					text = <"Korrigert">
+					description = <"Etter å ha vært satt som status \"Endelig\", har det blitt lagt nytt innhold til rapporten. Det eksisterende innholdet er uendret. Dette er en underkategori av \"Revidert\"">
+				>
+				["at0020"] = <
+					text = <"Revidert">
+					description = <"Resultatet har blitt modifisert etter å ha vært i status \"Endelig\", og er komplett og verifisert av ansvarlig person, og resultatdata er endret.">
+				>
+				["at0021"] = <
+					text = <"Tillegg">
+					description = <"Etter å ha vært satt som status \"Endelig\", har det blitt lagt nytt innhold til rapporten. Det eksisterende innholdet er uendret. Dette er en underkategori av \"Revidert\".">
+				>
+				["at0022"] = <
+					text = <"Feilregistrert">
+					description = <"Analyseresultatet har blitt trukket tilbake etter å ha vært i status Endelig.">
+				>
+				["at0023"] = <
+					text = <"Kansellert">
+					description = <"Resultatet er utilgjengelig fordi analysen ikke ble påbegynt eller ferdigstilt (også kalt \"avbrutt\").">
+				>
+				["at0024"] = <
+					text = <"Analysenavn">
+					description = <"Navnet på analyseresultatet.">
+					comment = <"Verdien for dette elementet blir vanligvis lagt inn i en spesialisering av denne arketypen, i en templat, eller i applikasjonen. For eksempel \"serum natrium\" eller \"hemoglobin\". Det er sterkt anbefalt å kode dette elementet med en terminologi, for eksempel Norsk laboratoriekodeverk, NPU, LOINC, SNOMED CT eller lokale kodesett.">
+					hl7v2_mapping = <"OBX.3">
+					fhir_mapping = <"Observation.code">
+				>
+				["at0025"] = <
+					text = <"Tidspunkt for medisinsk validering">
+					description = <"Datoen og tidspunktet da analyseresultatet ble medisinsk validert i laboratoriet.">
+					comment = <"I mange myndighetsområder omfatter \"Resultatstatus\" implisitt medisinsk validering, det vil si at et resultat med status \"Endelig\" vil antas å være medisinsk validert. I andre myndighetsområder kan dette registreres og rapporteres separat ved hjelp av dette dataelementet.">
+				>
+				["at0026"] = <
+					text = <"Prøvemateriale">
+					description = <"Identifikator eller link til prøvematerialet som ble brukt i analysen.">
+					comment = <"I noen situasjoner vil én Laboratorieresultat-arketype inneholde flere Prøvemateriale-arketyper og flere Analyseresultat-arketyper. I disse situasjonene må man bruke dette elementet for å kunne koble resultatene til de korrekte prøvematerialene.">
+				>
+				["at0027"] = <
+					text = <"Resultatrekkefølge">
+					description = <"Plasseringen av dette analyseresultatet i den overordnede rekkefølgen av resultater.">
+					comment = <"For eksempel \"1\", \"2\", \"3\". Dersom det er flere analyseresultater i en rapport gjør \"Resultatrekkefølge\" rekkefølgen i svarrapporten eksplisitt.">
+				>
+				["at0028"] = <
+					text = <"Testmetode">
+					description = <"Beskrivelse av metoden brukt for analysering av denne analytten.">
+					comment = <"Hvis testmetoden gjelder for hele testpanelet kan metoden beskrives ved å bruke \"Testing method\" (Testmetode) dataelementet i arketypen OBSERVATION.laboratory_test_result (Laboratorieresultat).">
+				>
+				["at0031"] = <
+					text = <"Tidspunkt for utført analyse">
+					description = <"Dato og tidspunkt da analytten ble analysert i laboratoriet.">
+					comment = <"Representerer det faktiske analysetidspunktet, uavhengig av når resultatet registreres eller rapporteres.">
+				>
+				["at0032"] = <
+					text = <"Akkreditert">
+					description = <"Indikerer om analysemetoden som er brukt for dette analyttet, er akkreditert.">
+					comment = <"Understøtter kvalitetssikring og etterlevelse av regelverk ved å angi om laboratorieanalysen ble utført etter en akkreditert metode.">
+				>
+			>
+		>
+		["pt-br"] = <
+			items = <
+				["at0000"] = <
+					text = <"*Laboratory analyte result(en)">
+					description = <"*The result of a laboratory test for a single analyte value.(en)">
+				>
+				["at0001"] = <
+					text = <"*Analyte result(en)">
+					description = <"*The value of the analyte result.(en)">
+					comment = <"*For example '7.3 mmol/l', 'Raised'. The 'Any' data type will need to be constrained to an appropriate data type in a specialisation, a template or at run-time to reflect the actual analyte result. The Quantity data type has reference model attributes that include flags for normal/abnormal, reference ranges and approximations - see https://specifications.openehr.org/releases/RM/latest/data_types.html#_dv_quantity_class for more details.(en)">
+					hl7v2_mapping = <"*OBX.2,OBX.5,OBX.6(en)">
+					fhir_mapping = <"*Observation.value[x](en)">
+				>
+				["at0003"] = <
+					text = <"*Comment(en)">
+					description = <"*Additional narrative about the analyte result, not captured in other fields.(en)">
+					hl7v2_mapping = <"*NTE.3(en)">
+					fhir_mapping = <"*Observation.comments(en)">
+				>
+				["at0004"] = <
+					text = <"*Reference range guidance(en)">
+					description = <"*Additional advice on the applicability of the reference range to this result or may carry text or coded textual guidance as to whether the result is within the normal range.(en)">
+					comment = <"*For example, 'within normal limits for age and sex'.(en)">
+				>
+				["at0005"] = <
+					text = <"*Result status(en)">
+					description = <"*The status of the analyte result value.(en)">
+					comment = <"*The values have been specifically chosen to match those in the HL7 FHIR Diagnostic report, historically derived from HL7v2 practice. Other local codes/terms can be used via the Text 'choice'.
+
+This element is multiple occurrence to cater for the use cases where there are more than one type of status need to be implemented by using two or more instances of this data element. (en)">
+					hl7v2_mapping = <"*OBX-11-observation result status(en)">
+					fhir_mapping = <"*status(en)">
+				>
+				["at0006"] = <
+					text = <"*Result status time(en)">
+					description = <"*The date and time that the analyte result was issued for the recorded ‘Result status’.(en)">
+					hl7v2_mapping = <"*OBX-22 and/or OBX-19(en)">
+					fhir_mapping = <"*Observation.issued(en)">
+				>
+				["at0014"] = <
+					text = <"Detalhes do resultado do analito">
+					description = <"Detalhes adicionais relativos a um resultado individual.">
+				>
+				["at0015"] = <
+					text = <"Registrado">
+					description = <"A existência do teste é registrada no sistema de informação do laboratório, mas não há nada disponível ainda.">
+				>
+				["at0016"] = <
+					text = <"Parcial">
+					description = <"Este é um resultado de teste parcial (p.e. inicial, intermediário ou preliminar): dados no resultado do teste podem estar incompletos ou não verificados.">
+				>
+				["at0017"] = <
+					text = <"Preliminar">
+					description = <"Resultados iniciais verificados estão disponíveis, mas nem todos os resultados são definitivos. Esta é uma sub-categoria de \"Parcial\".">
+				>
+				["at0018"] = <
+					text = <"Final">
+					description = <"O resultado final está completo e verificado por uma pessoa autorizada.">
+				>
+				["at0019"] = <
+					text = <"*Corrected(en)">
+					description = <"*The result has been modified subsequent to being Final, and is complete and verified by an authorised person. This is a sub-category of 'Amended'. (en)">
+				>
+				["at0020"] = <
+					text = <"*Amended(en)">
+					description = <"*The result has been modified subsequent to being Final, and is complete and verified by an authorised person, and result data has been changed. (en)">
+				>
+				["at0021"] = <
+					text = <"*Appended(en)">
+					description = <"*Subsequent to being final, the report has been modified by adding new content. The existing content is unchanged. This is a sub-category of 'Amended'.(en)">
+				>
+				["at0022"] = <
+					text = <"Entrada com erro">
+					description = <"O resultado do teste foi retirado após ser finalizado.">
+				>
+				["at0023"] = <
+					text = <"Cancelado">
+					description = <"O resultado está indisponível porque o teste não foi iniciado ou não foi completado (algumas vezes chamado de \"abortado\").">
+				>
+				["at0024"] = <
+					text = <"*Analyte name(en)">
+					description = <"*The name of the analyte result.(en)">
+					comment = <"*The value for this element is normally supplied in a specialisation, in a template or at run-time to reflect the actual analyte. For example: 'Serum sodium', 'Haemoglobin'. Coding with an external terminology is strongly recommended, such as LOINC, NPU, SNOMED CT, or local lab terminologies.(en)">
+					hl7v2_mapping = <"*OBX-3.1;3.2(en)">
+					fhir_mapping = <"*Observation.code(en)">
+				>
+				["at0025"] = <
+					text = <"*Validation time(en)">
+					description = <"*The date and time that the analyte result was validated in the laboratory by a healthcare practitioner.(en)">
+					comment = <"*In many jurisdictions the 'Result status' is assumed to include medical validation i.e. a 'final' result will be assumed to be medically validated, but in others this will be recorded and reported separately using this data element.(en)">
+				>
+				["at0026"] = <
+					text = <"*Specimen(en)">
+					description = <"*Identification of the specimen used for the analyte result.(en)">
+					comment = <"*In some situations, a single Laboratory test result archetype will contain multiple Specimen archetypes and multiple Analyte result archetypes. In these situations, this 'Specimen' data element is needed to be able to connect the results with the correct specimens.(en)">
+				>
+				["at0027"] = <
+					text = <"*Analyte result sequence(en)">
+					description = <"*">
+				>
+				["at0028"] = <
+					text = <"*Test method (en)">
+					description = <"*Description about the method used to perform the test on this analyte only. (en)">
+					comment = <"*If the test method applies to an entire panel, the test method can be captured using the 'Test method' data element within the OBSERVATION.laboratory_test_result (en)">
+				>
+				["at0031"] = <
+					text = <"*Analysis performed time (en)">
+					description = <"*The date and time when the analyte result was performed in the laboratory by a healthcare practitioner. (en)">
+					comment = <"*Represents the actual analysis timestamp, independent of when the result is recorded or reported. (en)">
+				>
+				["at0032"] = <
+					text = <"*Accredited (en)">
+					description = <"*Indicates whether the analytical method used for this analyte is accredited. (en)">
+					comment = <"*Supports quality assurance and regulatory compliance by specifying whether the laboratory analysis was performed under an accredited method. (en)">
+				>
+			>
+		>
+		["de"] = <
+			items = <
+				["at0000"] = <
+					text = <"Laboranalyt-Ergebnis">
+					description = <"Ergebnis einer Laboranalyse für einen bestimmten Analytwert.">
+				>
+				["at0001"] = <
+					text = <"Analyt-Ergebnis">
+					description = <"(Mess-)Wert des Analyt-Ergebnisses.">
+					comment = <"Z.B. \"7,3 mmol/l\", \"Erhöht\". Der \"Any\"-Datentyp wird dann durch eine Spezialisierung, eine Vorlage oder zur Laufzeit der Anwendung auf einen passenden Datentyp eingeschränkt werden müssen, um das aktuelle Analyt-Ergebnis wiederzugeben. Der \"Quantity\"-Datentyp hat Referenzmodell-Attribute, wie Kennungen für normal/abnormal, Referenzbereiche und Näherungen - für weitere Details s. https://specifications.openehr.org/releases/RM/latest/data_types.html#_dv_quantity_class .">
+					hl7v2_mapping = <"OBX.2, OBX.5, OBX.6, OBX.7, OBX.8">
+					fhir_mapping = <"Observation.value[x]">
+				>
+				["at0003"] = <
+					text = <"Kommentar">
+					description = <"Kommentar zum Analyt-Ergebnis, soweit noch nicht in anderen Feldern erfasst.">
+					hl7v2_mapping = <"NTE.3">
+					fhir_mapping = <"Observation.note">
+				>
+				["at0004"] = <
+					text = <"Referenzbereichs-Hinweise">
+					description = <"Zusätzliche Hinweise zur Anwendbarkeit des Referenzbereichs für dieses Resultat oder (codierter) Text, ob das Ergebnis im Referenzbereich ist oder nicht.">
+					comment = <"z.B.: 'im Referenzbereich, bezogen auf Alter und Geschlecht'.">
+				>
+				["at0005"] = <
+					text = <"Ergebnis-Status">
+					description = <"Status des Analyt-Ergebniswertes.">
+					comment = <"Die Werte wurden speziell so ausgewählt, dass sie mit denen im HL7 FHIR-Diagnosebericht übereinstimmen, der ursprünglich aus der HL7v2-Praxis abgeleitet wurde. Andere lokale Codes / Begriffe können über die Textauswahl verwendet werden.
+
+Dieses Element ermöglicht mehrere Vorkommen, um Anwendungsfälle zu unterstützen, wo mehr als eine Art von Status implementiert werden muss.">
+					hl7v2_mapping = <"OBX.11">
+					fhir_mapping = <"Observation.status">
+				>
+				["at0006"] = <
+					text = <"Zeitpunkt Ergebnis-Status">
+					description = <"Datum und/oder Zeitpunkt an dem der Status für das Analyseergebnis gesetzt wurde.">
+					hl7v2_mapping = <"OBX.19">
+					fhir_mapping = <"Observation.issued">
+				>
+				["at0014"] = <
+					text = <"Analyseergebnis-Detail">
+					description = <"Weitere Details zu einem einzelnen Ergebnis.">
+				>
+				["at0015"] = <
+					text = <"Registriert">
+					description = <"Der Test ist im Laborinformationssystem registriert, aber noch kein Ergebnis verfügbar.">
+				>
+				["at0016"] = <
+					text = <"Unvollständig">
+					description = <"Das Testergebnis ist ein Anfangs- oder Interimswert: Daten im Testergebnis können unvollständig oder nicht verifiziert/validiert sein.">
+				>
+				["at0017"] = <
+					text = <"Vorläufig">
+					description = <"Erste, verifizierte Resultate sind vorhanden, der Test ist aber noch nicht abgeschlossen (Sub-Kategorie von 'Unvollständig').">
+				>
+				["at0018"] = <
+					text = <"Endbefund">
+					description = <"Das Analyseergebnis ist vollständig und durch eine autorisierte Person verifiziert.">
+				>
+				["at0019"] = <
+					text = <"Korrigiert">
+					description = <"Das Ergebnis wurde nach dem endgültigen Abschluss geändert und ist vollständig und wird von einer autorisierten Person überprüft. Dies ist eine Sub-Kategorie von \"Geändert\".">
+				>
+				["at0020"] = <
+					text = <"Geändert">
+					description = <"Das Ergebnis wurde nach dem endgültigen Abschluss geändert und ist vollständig und von einer autorisierten Person überprüft. Die Ergebnisdaten wurden geändert.">
+				>
+				["at0021"] = <
+					text = <"Ergänzt">
+					description = <"Nach Abschluss wurde der Bericht durch das Hinzufügen neuer Inhalte abgeändert. Die vorhandene Inhalte sind unverändert. Dies ist eine Sub-Kategorie von \"Geändert\".">
+				>
+				["at0022"] = <
+					text = <"Endbefund, widerrufen">
+					description = <"Das Testergebnis wurde nach Endbefundung zurückgezogen.">
+				>
+				["at0023"] = <
+					text = <"Storniert">
+					description = <"Das Testergebnis ist nicht verfügbar, weil der Test nicht gestartet oder nicht abgeschlossen wurde (manchmal auch als \"abgebrochen\" bezeichnet).">
+				>
+				["at0024"] = <
+					text = <"Bezeichnung des Analyts">
+					description = <"Der Name des untersuchten Analyts.">
+					comment = <"Der Wert dieses Elements wird normalerweise, meist durch eine Spezialisierung, in einem Template oder zur Laufzeit der Anwendung geliefert, um den aktuellen Analyt wiederzugeben. Zum Beispiel: 'Natrium im Serum', 'Hämoglobin'. 
+Die Codierung mit einer externen Terminologie, wie LOINC, NPU, SNOMED-CT oder lokalen Labor-Terminologien wird dringend empfohlen.
+">
+					hl7v2_mapping = <"OBX.3">
+					fhir_mapping = <"Observation.code">
+				>
+				["at0025"] = <
+					text = <"Zeitpunkt der Validierung">
+					description = <"Datum und Uhrzeit der Validierung des Analyt-Ergebnisses im Labor durch medizinisches Fachpersonal.">
+					comment = <"In vielen Gerichtsbarkeiten wird angenommen, dass der \"Ergebnis-Status\" die medizinische Validierung einschliesst, in anderen wird diese anhand dieses Datenelements separat erfasst und befundet.">
+				>
+				["at0026"] = <
+					text = <"Probe">
+					description = <"Kennung der Probe, die für das Analyseergebnis verwendet wurde.">
+					comment = <"In manchen Situationen wird ein einzelner Laborergebnis-Archetyp mehrere Probe- und Laboranalyt-Ergebnis-Archetypen enthalten. In diesen Fällen wird dieses \"Probe\"-Datenelement benötigt, um die Ergebnisse mit den richtigen Proben zu verknüpfen.">
+				>
+				["at0027"] = <
+					text = <"Analyseergebnis-Reihenfolge">
+					description = <"Die beabsichtigte Position dieses Analyseergebnisses in der Reihenfolge aller Analyseergebnisse.">
+					comment = <"z.B. '1', '2', '3'. Werden mehrere Analysenergebnisse berichtet, gibt die Analyseergebnis-Reihenfolge explizit die Reihenfolge der Analyseergebnisse an.">
+				>
+				["at0028"] = <
+					text = <"Testmethode">
+					description = <"Die Beschreibung der Methode, mit der der Test nur für diesen Analyten durchgeführt wurde.">
+					comment = <"Wenn die Testmethode für ein gesamtes Panel gilt, kann die Testmethode mithilfe des Datenelements \"Testmethode\" im Ergebnis OBSERVATION.laboratory_test_result erfasst werden.">
+				>
+				["at0031"] = <
+					text = <"Zeitpunkt der Analyse">
+					description = <"Datum und Uhrzeit der Durchführung des Analyt-Ergebnisses im Labor durch medizinisches Fachpersonal.">
+					comment = <"Stellt den tatsächlichen Analysezeitpunkt dar, unabhängig davon, wann das Ergebnis erfasst oder gemeldet wird.">
+				>
+				["at0032"] = <
+					text = <"Akkreditiert">
+					description = <"Gibt an, ob die für diesen Analyten verwendete Analysemethode akkreditiert ist.">
+					comment = <"Unterstützt die Qualitätssicherung und die Einhaltung gesetzlicher Vorschriften, indem angegeben wird, ob die Laboranalyse nach einer akkreditierten Methode durchgeführt wurde.">
+				>
+			>
+		>
+		["nl"] = <
+			items = <
+				["at0000"] = <
+					text = <"Laboratorium analyt uitslag">
+					description = <"Het resultaat van een laboratorium test voor een bepaling van een enkele bepaling.">
+				>
+				["at0001"] = <
+					text = <"Uitslag van een analyt">
+					description = <"De waarde van een analyt uitslag.">
+					comment = <"Bijvoorbeeld: '7.3 mmol/l', 'Verhoogd'. Om het daadwerkelijke analyt result weer te geven dient het 'Any' data type gespecificeerd te worden tot een toepasselijk data type in een specialisatie, een template of terwijl de applicatie loopt.">
+					hl7v2_mapping = <"OBX.2, OBX.5, OBX.6, OBX.7, OBX.8">
+					fhir_mapping = <"Observation.value[x]">
+				>
+				["at0003"] = <
+					text = <"Opmerking">
+					description = <"Extra beschrijving van de analyt uitslag, die niet past binnen andere velden.">
+					hl7v2_mapping = <"NTE.3">
+					fhir_mapping = <"Observation.note">
+				>
+				["at0004"] = <
+					text = <"Referentiebereik aanwijzing">
+					description = <"Extra advies over de toepasselijkheid van het referentiebereik van deze uitslag; mag ook een textuele of gecodeerd textuele aanwijzing bevatten of het resultaat binnen het normale bereik valt.">
+					comment = <"Bijvoorbeeld: 'binnen het normale bereik voor leeftijd en geslacht'">
+				>
+				["at0005"] = <
+					text = <"Uitslag status">
+					description = <"De status van de waarde van de analyt uitslag.">
+					comment = <"*The values have been specifically chosen to match those in the HL7 FHIR Diagnostic report, historically derived from HL7v2 practice. Other local codes/terms can be used via the Text 'choice'.
+
+This element is multiple occurrence to cater for the use cases where there are more than one type of status need to be implemented by using two or more instances of this data element. (en)">
+					hl7v2_mapping = <"OBX.11">
+					fhir_mapping = <"Observation.status">
+				>
+				["at0006"] = <
+					text = <"Tijd van de status van de uitslag">
+					description = <"De datum en tijd van de 'Status van de uitslag' van de analyt uitslag.">
+					hl7v2_mapping = <"OBX.19">
+					fhir_mapping = <"Observation.issued">
+				>
+				["at0014"] = <
+					text = <"Analyte uitslag details">
+					description = <"Verdere details over een individuele uitslag.">
+				>
+				["at0015"] = <
+					text = <"Vastgelegd">
+					description = <"Het bestaan van de test is vastgelegd in het Laboratorium informatie systeem, maar er is nog niets beschikbaar.">
+				>
+				["at0016"] = <
+					text = <"Gedeeltelijk">
+					description = <"Dit is een gedeeltelijke (bijvoorbeeld initiële, tussentijdse of voorlopige) Test Uitslag: data in de Test Uitslag kan incompleet of ongevalideerd zijn.">
+				>
+				["at0017"] = <
+					text = <"Voorlopig">
+					description = <"Gevalideerde uitslagen zijn beschikbaar, maar niet alle uitslagen zijn definitief. Dit is een subcategorie van 'Gedeeltelijk'.">
+				>
+				["at0018"] = <
+					text = <"Definitief">
+					description = <"De Test uitslag is compleet en geverifieerd door een bevoegd persoon.">
+				>
+				["at0019"] = <
+					text = <"Gewijzigd">
+					description = <"*The result has been modified subsequent to being Final, and is complete and verified by an authorised person. This is a sub-category of 'Amended'. (en)">
+				>
+				["at0020"] = <
+					text = <"Aangepast">
+					description = <"*The result has been modified subsequent to being Final, and is complete and verified by an authorised person, and result data has been changed. (en)">
+				>
+				["at0021"] = <
+					text = <"Informatie toegevoegd">
+					description = <"Er is nieuwe informatie toegevoegd nadat het verslag eerder Definitief was. De bestaande informatie is onveranderd. Dit is een subcategorie van 'Aangepast'.">
+				>
+				["at0022"] = <
+					text = <"Verkeerd ingevoerd">
+					description = <"De Tets Uitslag is teruggetrokken nadat hij eerder definitief was.">
+				>
+				["at0023"] = <
+					text = <"Geanuleerd">
+					description = <"De uitslag is niet beschikbaar omdat de test niet gestart of niet compleet was.">
+				>
+				["at0024"] = <
+					text = <"Naam van het Analyt">
+					description = <"De naam van de analyt uitslag">
+					comment = <"De waarde voor dit element wordt normaal bepaald in een specialisatie, in een template of terwijl de applicatie loopt om het daadwerkelijke analyt weer te geven. Bijvoorbeeld: 'Serum natrium' of 'Haemoglobine'. Het wordt sterk aanbevolen te coderen met een externe terminologie, zoals LOINC, NPU, SNOMED CT, of een lokale lab terminologie.">
+					hl7v2_mapping = <"OBX.3">
+					fhir_mapping = <"Observation.code">
+				>
+				["at0025"] = <
+					text = <"Tijd van validatie">
+					description = <"De datum en tijd waarop de analyt uitslag werd gevalideerd in het laboratorium door een gezondheidsprofessional.">
+					comment = <"In veel jurisdicties wordt aangenomen dat de 'Status van de uitslag' een medische validatie bevat, bijvoorbeeld: een 'definitieve' uitslag wordt opgevat als medisch gevalideerd, maar in de andere gebieden wordt deze status apart vastgelegd in dit data element.">
+				>
+				["at0026"] = <
+					text = <"Specimen">
+					description = <"Identificatie van het specimen/monster gebruikt voor de analyt uitslag">
+					comment = <"In sommige situaties, zal een enkel Laboratorium test archetype meerdere Specimen archetypes en meerdere Analyt uitslag archetypes bevatten. In deze situaties is dit 'Specimen' data element nodig om de uitslag met het juiste monster te verbinden.">
+				>
+				["at0027"] = <
+					text = <"Analyt uitslag volgore">
+					description = <"De bedoelde positie van deze analyt uitslag binnen de gehele volgorde van analyt uitslagen.">
+					comment = <"Bijvoorbeeld: '1', '2' of '3'. Waar meerdere analyt uitslagen worden gerapporteerd, maakt de 'Analyt uitslag volgorde' de volgorde waarin de uitslagen worden gerapporteerd expliciet.">
+				>
+				["at0028"] = <
+					text = <"Test methode">
+					description = <"Omschrijving van de methode die gebruikt is als onderzoek voor specifiek dit analyt.">
+					comment = <"Als de test methode van toepassing is op het hele test panel, can de test methode vastgelegd worden middels het 'Test methode' data element in">
+				>
+				["at0031"] = <
+					text = <"*Analysis performed time (en)">
+					description = <"*The date and time when the analyte result was performed in the laboratory by a healthcare practitioner. (en)">
+					comment = <"*Represents the actual analysis timestamp, independent of when the result is recorded or reported. (en)">
+				>
+				["at0032"] = <
+					text = <"*Accredited (en)">
+					description = <"*Indicates whether the analytical method used for this analyte is accredited. (en)">
+					comment = <"*Supports quality assurance and regulatory compliance by specifying whether the laboratory analysis was performed under an accredited method. (en)">
+				>
+			>
+		>
+		["sv"] = <
+			items = <
+				["at0000"] = <
+					text = <"Analysresultat">
+					description = <"Resultatet för en enskild analys i en laboratorieundersökning.">
+				>
+				["at0001"] = <
+					text = <"Analysresultat">
+					description = <"Analysresultatets värde">
+					comment = <"Till exempel \"7,3 mmol/L\" eller \"Förhöjd\". Datatypen \"Any\", som är en odefinierad datatyp, måste begränsas till en lämplig datatyp i en specialisering, mall eller applikation. Datatypen \"Quantity\" har attribut från referensmodellen som täcker flaggor för normal/onormal, referensområden och approximationer.
+Se https://specifications.openehr.org/releases/RM/latest/data_types.html#_dv_quantity_class för mer information.">
+					hl7v2_mapping = <"OBX.2, OBX.5, OBX.6, OBX.7, OBX.8">
+					fhir_mapping = <"Observation.value[x]">
+				>
+				["at0003"] = <
+					text = <"Kommentar">
+					description = <"Ytterligare fritext om analysresultatet som inte fångas av andra dataelement.">
+				>
+				["at0004"] = <
+					text = <"Vägledning för referensintervall">
+					description = <"Ytterligare vägledning för information om referensintervallet är tillämpbart för detta resultat. Kan innehålla text eller kodad text med råd om huruvida resultatet ligger inom det normala intervallet.
+">
+					comment = <"Till exempel \"inom normalområde avseende ålder och kön\".">
+				>
+				["at0005"] = <
+					text = <"Resultatstatus">
+					description = <"Status för analysresultatet.">
+					comment = <"Värdena har valts specifikt för att motsvara de i HL7 FHIR-resursen \"Diagnostic report\", som historiskt kommer från praxis i HL7 v2. Andra lokala koder eller termer kan användas med datatypen \"Fri eller kodad text\".
+
+Det här fältet kan repeteras för att stödja användningsfall där behov finns av flera statustyper.">
+					hl7v2_mapping = <"OBX.11">
+					fhir_mapping = <"Observation.status">
+				>
+				["at0006"] = <
+					text = <"Tidsangivelse för resultatstatus">
+					description = <"Datum och tid då analysresultatet utfärdades för den aktuella resultatstatusen.">
+				>
+				["at0014"] = <
+					text = <"Detaljer om analysresultat">
+					description = <"Ytterligare detaljer om ett enskilt analysresultat.">
+				>
+				["at0015"] = <
+					text = <"Registrerad">
+					description = <"Analysen är registrerad i laboratoriesystemet, men resultatet är ej ännu tillgängligt.
+
+">
+				>
+				["at0016"] = <
+					text = <"Partiellt resultat">
+					description = <"Detta är ett partiellt (dvs. initialt eller preliminärt) testresultat: Data i resultatet kan vara ofullständiga eller obekräftade.">
+				>
+				["at0017"] = <
+					text = <"Preliminärt resultat">
+					description = <"Verifierade tidiga resultat är tillgängliga, men inte alla resultat är slutgiltiga. Detta är en underkategori av \"Partiellt resultat\".">
+				>
+				["at0018"] = <
+					text = <"Slutgiltigt resultat">
+					description = <"Testresultatet är fullständigt och verifierat av en auktoriserad person.">
+				>
+				["at0019"] = <
+					text = <"Slutgiltigt resultat, korrigerat">
+					description = <"Resultatet har korrigerats efter att tidigare ha varit markerat som slutgiltigt. Detta är en underkategori av \"Slutgiltigt resultat, reviderat\".">
+				>
+				["at0020"] = <
+					text = <"Slutgiltigt resultat, reviderat">
+					description = <"Resultatet har reviderats och ändrats efter att tidigare ha varit markerat som slutgiltigt.">
+				>
+				["at0021"] = <
+					text = <"Slutgiltigt resultat, tillägg">
+					description = <"Efter att ha slutförts har resultatrapporten ändrats genom att nytt innehåll har inkluderats. Det befintliga innehållet är oförändrat. Detta är en underkategori av ”Slutgiltigt svar, reviderat”.">
+				>
+				["at0022"] = <
+					text = <"Felaktigt registrerat resultat">
+					description = <"Analysresultatet har dragits tillbaka efter att ha varit i status \"Slutgiltigt resultat\".">
+				>
+				["at0023"] = <
+					text = <"Avbrutet">
+					description = <"Resultatet är inte tillgängligt eftersom testet inte har startats eller inte slutförts (kallas även ibland för \"inställt\").">
+				>
+				["at0024"] = <
+					text = <"Analysnamn">
+					description = <"Namnet på analysen.">
+					comment = <"Värdet för detta fält anges vanligtvis i en specialisering av den här arketypen, i en mall eller i applikationen. Till exempel \"S-natrium\" eller \"hemoglobin\". Det rekommenderas starkt att koda med en terminologi såsom exempelvis NPU, LOINC, SNOMED CT eller lokala kodverk.">
+					hl7v2_mapping = <"OBX.3">
+					fhir_mapping = <"Observation.code">
+				>
+				["at0025"] = <
+					text = <"Tidpunkt för validering">
+					description = <"Datum och tid då analysresultatet validerades medicinskt i laboratoriet.
+">
+					comment = <"I många fall antas 'resultatstatus' inkludera medicinsk validering, dvs. ett \"slutligt\" resultat antas vara medicinskt validerat. I andra fall kommer detta att registreras och rapporteras separat med hjälp av detta fält.
+
+
+">
+				>
+				["at0026"] = <
+					text = <"Provmaterial">
+					description = <"Identifiering av det provmaterial som använts för analysresultatet.">
+					comment = <"I vissa situationer kommer en arketyp för laboratorietestresultat (OBSERVATION.Laboratory_test_result) att innehålla flera arketyper för provmaterial (Specimen) och flera arketyper för analysresultat (Laboratory_analyte_result). I dessa situationer måste man använda detta dataelement för att kunna koppla resultaten till rätt provmaterial.">
+				>
+				["at0027"] = <
+					text = <"Rapporteringsordning">
+					description = <"Den faktiska positionen för ett enskilt analysresultat i den totala rapporteringsordningen.
+
+
+
+">
+					comment = <"Till exempel 1, 2 eller 3. Om flera analysresultat rapporteras visar detta värde var i ordningsföljden detta resultat har besvarats. 
+
+
+
+">
+				>
+				["at0028"] = <
+					text = <"Testmetod">
+					description = <"Beskrivning av metoden som har använts för att utföra testet specifikt för denna analyt.
+">
+					comment = <"Om testmetoden gäller för en hel panel kan testmetoden fångas med hjälp av dataelementet 'Testmetod' i OBSERVATION.laboratory_test_result.">
+				>
+				["at0031"] = <
+					text = <"*Analysis performed time (en)">
+					description = <"*The date and time when the analyte result was performed in the laboratory by a healthcare practitioner. (en)">
+					comment = <"*Represents the actual analysis timestamp, independent of when the result is recorded or reported. (en)">
+				>
+				["at0032"] = <
+					text = <"*Accredited (en)">
+					description = <"*Indicates whether the analytical method used for this analyte is accredited. (en)">
+					comment = <"*Supports quality assurance and regulatory compliance by specifying whether the laboratory analysis was performed under an accredited method. (en)">
+				>
+			>
+		>
+		["es"] = <
+			items = <
+				["at0000"] = <
+					text = <"Resultado de laboratorio del analito">
+					description = <"Resultado de una prueba de laboratorio para un valor de analito único.">
+				>
+				["at0001"] = <
+					text = <"Resultado del analito">
+					description = <"Valor del resultado del analito.">
+					comment = <"Por ejemplo, \"7,3 mmol/l\", \"Elevado\". El tipo de datos \"Cualquiera\" deberá limitarse a un tipo de datos adecuado en una especialización, una plantilla o en tiempo de ejecución para reflejar el resultado real del analito. El tipo de dato \"Cantidad\" tiene atributos de modelo de referencia que incluyen indicadores de normalidad/anormalidad, rangos de referencia y aproximaciones (para más información, véase https://specifications.openehr.org/releases/RM/latest/data_types.html#_dv_quantity_class).">
+					hl7v2_mapping = <"OBX.2, OBX.5, OBX.6, OBX.7, OBX.8">
+					fhir_mapping = <"Observation.value[x]">
+				>
+				["at0003"] = <
+					text = <"Comentarios">
+					description = <"Narración adicional sobre el resultado del analito, no registrada en otros campos.">
+					hl7v2_mapping = <"NTE.3">
+					fhir_mapping = <"Observation.note">
+				>
+				["at0004"] = <
+					text = <"Intervalos de referencia">
+					description = <"Asesoramiento adicional sobre la aplicabilidad del intervalo de referencia a este resultado, o bien se puede incluir un texto o guía textual codificada sobre si el resultado está dentro del intervalo normal.
+">
+					comment = <"Por ejemplo, \"dentro de los límites normales para la edad y el sexo\".">
+				>
+				["at0005"] = <
+					text = <"Estado del resultado">
+					description = <"Estado del valor del resultado del analito.">
+					comment = <"Los valores se han elegido específicamente para que coincidan con los del informe HL7 FHIR Diagnostic, derivados históricamente de la práctica HL7v2. Pueden utilizarse otros códigos/términos locales mediante el texto \"choice\".
+
+Este elemento permite múltiples ocurrencias para admitir casos de uso en los que es necesario implementar más de un tipo de estado.">
+					hl7v2_mapping = <"OBX.11">
+					fhir_mapping = <"Observation.status">
+				>
+				["at0006"] = <
+					text = <"Fecha/Hora del estado del resultado">
+					description = <"Fecha y hora en que se emitió el resultado del analito para el estado más reciente.">
+					hl7v2_mapping = <"OBX.19">
+					fhir_mapping = <"Observation.issued">
+				>
+				["at0014"] = <
+					text = <"Detalle del resultado del analito">
+					description = <"Más detalles sobre un resultado individual.">
+				>
+				["at0015"] = <
+					text = <"Registrado">
+					description = <"La prueba está registrada en el Sistema de Información de Laboratorios, pero aún no hay nada disponible.">
+				>
+				["at0016"] = <
+					text = <"Parcial">
+					description = <"Resultado de prueba parcial (por ejemplo, inicial, provisional o preliminar): los datos del resultado de la prueba pueden estar incompletos o sin verificar.">
+				>
+				["at0017"] = <
+					text = <"Preliminar">
+					description = <"Los primeros resultados verificados están disponibles, pero no son definitivos. Se trata de una subcategoría de \"Parcial\".">
+				>
+				["at0018"] = <
+					text = <"Final">
+					description = <"El resultado de la prueba está completo y ha sido verificado por una persona autorizada.">
+				>
+				["at0019"] = <
+					text = <"Corregido">
+					description = <"El resultado se ha modificado con posterioridad al estado \"Final\". Está completo y verificado por una persona autorizada. Se trata de una subcategoría de \"Modificado\".">
+				>
+				["at0020"] = <
+					text = <"Modificado">
+					description = <"El resultado se ha modificado con posterioridad al estado \"Final\". Está completo y verificado por una persona autorizada, y se han cambiado los datos del resultado.">
+				>
+				["at0021"] = <
+					text = <"Anexo">
+					description = <"Tras pasar a estado \"Final\", el informe se ha modificado añadiendo nuevos contenidos. El contenido existente no ha cambiado. Se trata de una subcategoría de 'Modificado'.">
+				>
+				["at0022"] = <
+					text = <"Introducido por error">
+					description = <"El resultado de la prueba ha sido retirado tras haberse publicado.">
+				>
+				["at0023"] = <
+					text = <"Cancelado">
+					description = <"El resultado no está disponible porque la prueba no se ha iniciado o no se ha completado (a veces también se denomina \"anulada\").">
+				>
+				["at0024"] = <
+					text = <"Nombre del analito">
+					description = <"Nombre del resultado del analito.">
+					comment = <"El valor de este elemento se suministra normalmente en una especialización, en una plantilla o en tiempo de ejecución para reflejar el analito real. Por ejemplo: \"Sodio sérico\", \"Hemoglobina\". Se recomienda encarecidamente la codificación con una terminología externa, como LOINC, NPU, SNOMED CT o terminologías de laboratorio locales.">
+					hl7v2_mapping = <"OBX.3">
+					fhir_mapping = <"Observation.code">
+				>
+				["at0025"] = <
+					text = <"Tiempo de validación">
+					description = <"Fecha y hora en que un profesional sanitario validó el resultado del analito en el laboratorio.">
+					comment = <"En muchas jurisdicciones se asume que el \"Estado del resultado\" incluye la validación médica, es decir, se asumirá que un resultado \"final\" está validado médicamente, pero en otras esto se registrará y notificará por separado utilizando este elemento de datos.">
+				>
+				["at0026"] = <
+					text = <"Muestra">
+					description = <"Identificación de la muestra utilizada para el resultado del analito.">
+					comment = <"En algunas situaciones, un único arquetipo de Resultado de Pruebas de Laboratorio podría contener varios arquetipos de muestra y varios arquetipos de resultados del analito. En estas situaciones, el elemento de datos 'Muestra' es necesario para poder conectar los resultados con las muestras correctas.">
+				>
+				["at0027"] = <
+					text = <"Secuencia de resultados del analito">
+					description = <"Posición prevista del resultado del analito dentro de la secuencia general de resultados del analito.">
+					comment = <"Por ejemplo: \"1\", \"2\", \"3\". Si se notifican varios resultados de analitos, la \"Secuencia de resultados del analito\" indica explícitamente el orden en que se notificaron.">
+				>
+				["at0028"] = <
+					text = <"Método de prueba">
+					description = <"Descripción del método utilizado para realizar la prueba sólo con este analito.">
+					comment = <"Si el método de prueba se aplica a un panel completo, puede capturarse utilizando el elemento de datos \"Método de prueba\" dentro de OBSERVATION.laboratory_test_result.">
+				>
+				["at0031"] = <
+					text = <"*Analysis performed time (en)">
+					description = <"*The date and time when the analyte result was performed in the laboratory by a healthcare practitioner. (en)">
+					comment = <"*Represents the actual analysis timestamp, independent of when the result is recorded or reported. (en)">
+				>
+				["at0032"] = <
+					text = <"*Accredited (en)">
+					description = <"*Indicates whether the analytical method used for this analyte is accredited. (en)">
+					comment = <"*Supports quality assurance and regulatory compliance by specifying whether the laboratory analysis was performed under an accredited method. (en)">
+				>
+			>
+		>
+		["ca"] = <
+			items = <
+				["at0000"] = <
+					text = <"Resultat de l'anàlit de laboratori">
+					description = <"Resultat d'una prova de laboratori per a un únic valor d'anàlit.">
+				>
+				["at0001"] = <
+					text = <"Resultat de l'anàlit">
+					description = <"Valor del resultat de l'anàlit.">
+					comment = <"Per exemple, «7,3 mmol/l», «Elevat». El tipus de dades «Qualsevol» s'haurà de restringir a un tipus de dades apropiat en una especialització, una plantilla o en un temps d'execució per a reflectir el resultat real de l’anàlit. El tipus de dades «Quantitat» té atributs de model de referència que inclouen indicadors per a normal/anormal, rangs de referència i aproximacions. Veure https://specifications.openehr.org/releases/RM/latest/data_types.html#_dv_quantity_class per a obtindre més detalls.">
+					hl7v2_mapping = <"OBX.2, OBX.5, OBX.6, OBX.7, OBX.8">
+					fhir_mapping = <"Observation.value[x]">
+				>
+				["at0003"] = <
+					text = <"Observacions">
+					description = <"Informació addicional sobre el resultat de l'anàlit no recollida en altres caselles.">
+					hl7v2_mapping = <"NTE.3">
+					fhir_mapping = <"Observation.note">
+				>
+				["at0004"] = <
+					text = <"Instruccions dels rangs de referència">
+					description = <"Consells addicionals sobre l'aplicabilitat del rang de referència per a aquest resultat, o es pot incloure un text o guia textual programada sobre si el resultat es troba dins del rang normal.">
+					comment = <"Per exemple, «dins dels límits normals per a l’edat i el sexe».">
+				>
+				["at0005"] = <
+					text = <"Estat del resultat">
+					description = <"L’estat del valor del resultat de l'anàlit.">
+					comment = <"Els valors s’han escollit específicament perquè coincideixin amb els de l’Informe de diagnòstic HLT7 FHIR, derivats històricament de la pràctica HL7v2. Es poden utilitzar altres codis/termes mitjançant l'«elecció» del Text.
+
+Aquest element permet múltiples esdeveniments per admetre casos d'ús on calgui implementar més d'un tipus d'estat.">
+					hl7v2_mapping = <"OBX.11">
+					fhir_mapping = <"Observation.status">
+				>
+				["at0006"] = <
+					text = <"Data i hora de l'estat del resultat">
+					description = <"Data i hora en què es va emetre el resultat de l'anàlit per a «L'estat del Resultat» enregistrat.">
+					hl7v2_mapping = <"OBX.19">
+					fhir_mapping = <"Observation.issued">
+				>
+				["at0014"] = <
+					text = <"Detall del resultat de l'anàlit">
+					description = <"Més informació d'un resultat individual.">
+				>
+				["at0015"] = <
+					text = <"Registrat">
+					description = <"L'existència de la prova està registrada en el Sistema d'Informació del Laboratori, però encara no hi ha res disponible.">
+				>
+				["at0016"] = <
+					text = <"Parcial">
+					description = <"Aquest és un Resultat de la Prova parcial (per exemple; inicial, provisional o preliminar): les dades del Resultat de la Prova poden estar incompletes o sense verificar.">
+				>
+				["at0017"] = <
+					text = <"Preliminar">
+					description = <"Es disposa de resultats preliminars verificats, però no tots els resultats són definitius. Aquesta és una subcategoria de «Parcial».">
+				>
+				["at0018"] = <
+					text = <"Definitiu">
+					description = <"El resultat de la Prova està complet i l’ha verificat una persona autoritzada.">
+				>
+				["at0019"] = <
+					text = <"Corregit">
+					description = <"S’ha modificat el resultat després d’esdevenir Definitiu i està complet i verificat per una persona autoritzada. Aquesta és una subcategoria de «Modificat».">
+				>
+				["at0020"] = <
+					text = <"Modificat">
+					description = <"S’ha modificat el resultat després d’esdevenir Definitiu, està complet i verificat per una persona autoritzada i les dades del resultat s’han modificat.">
+				>
+				["at0021"] = <
+					text = <"Annex">
+					description = <"Després d’esdevenir definitiu, l’informe s’ha modificat afegint-hi continguts nous. No s’ha modificat el contingut existent. Aquesta és una subcategoria de «Modificat».">
+				>
+				["at0022"] = <
+					text = <"Introduït per error">
+					description = <"El Resultat de la Prova s’ha retirat després de la publicació Definitiva anterior.">
+				>
+				["at0023"] = <
+					text = <"Cancel·lat">
+					description = <"El resultat no està disponible perquè la prova no s’ha iniciat o no s’ha completat (de vegades també s’anomena «Interromput»).">
+				>
+				["at0024"] = <
+					text = <"Nom de l'anàlit">
+					description = <"Nom del resultat de l'anàlit.">
+					comment = <"El valor per a aquest element normalment s’aporta mitjançant una especialització, en una plantilla o en un temps d'execució per a reflectir l’anàlit real. Per exemple: «Sodi sèric», «Hemoglobina». Es recomana encaridament programar amb terminologia externa, com LOINC, NPU, SNOMED CT o terminologies de laboratoris locals.">
+					hl7v2_mapping = <"OBX.3">
+					fhir_mapping = <"Observation.code">
+				>
+				["at0025"] = <
+					text = <"Temps de validació">
+					description = <"Data i hora en què un professional sanitari va validar el resultat de l'anàlit en un laboratori.">
+					comment = <"En moltes jurisdiccions, «L'estat del resultat» es pressuposa que inclou validació mèdica. És a dir, es pressuposarà que un resultat «definitiu» estarà validat mèdicament, però en altres es registrarà i notificarà per separat utilitzant aquest element de dades.">
+				>
+				["at0026"] = <
+					text = <"Mostra">
+					description = <"Identificació de la mostra utilitzada per al resultat de l'anàlit.">
+					comment = <"En algunes situacions, un únic arquetip de resultat de proves de laboratori contindrà múltiples arquetips de mostra i diversos arquetips de resultat de l'anàlit. En aquestes situacions, aquest element de dades de «Mostra» ha de poder connectar els resultats amb les mostres correctes.">
+				>
+				["at0027"] = <
+					text = <"Seqüència de resultats de l'analit">
+					description = <"Posició prevista d'aquest resultat d'anàlit dins de la seqüència general dels resultats de l'anàlit.">
+					comment = <"Per exemple: «1», «2», «3». On s'informen diversos resultats de l’anàlit, la «Seqüència de resultats de l'anàlit» és qui explicita l'ordre en què es van informar.">
+				>
+				["at0028"] = <
+					text = <"Mètode de prova">
+					description = <"Descripció sobre el mètode utilitzat per a dur a terme la prova únicament en aquest anàlit.">
+					comment = <"Si el mètode de prova s'aplica a una llista completa, el mètode de prova es pot registrar utilitzant l’element de dades «Mètode de prova» dins de OBSERVATION.laboratory_test_result.">
+				>
+				["at0031"] = <
+					text = <"*Analysis performed time (en)">
+					description = <"*The date and time when the analyte result was performed in the laboratory by a healthcare practitioner. (en)">
+					comment = <"*Represents the actual analysis timestamp, independent of when the result is recorded or reported. (en)">
+				>
+				["at0032"] = <
+					text = <"*Accredited (en)">
+					description = <"*Indicates whether the analytical method used for this analyte is accredited. (en)">
+					comment = <"*Supports quality assurance and regulatory compliance by specifying whether the laboratory analysis was performed under an accredited method. (en)">
+				>
+			>
+		>
+		["zh-cn"] = <
+			items = <
+				["at0000"] = <
+					text = <"分析物检验结果">
+					description = <"单项分析物检验项目的结果。">
+				>
+				["at0001"] = <
+					text = <"分析物结果">
+					description = <"分析物结果的取值。">
+					comment = <"例如，“7.3 mmol/l”、“增高”。需要在特化原始型当中、在模板当中或在运行时将数据类型 'Any' 限制为恰当的数据类型，以反映实际的分析物结果。数据类型 Quantity 具有的参考模型属性包括正常/异常标志、参考范围和近似值。有关详细信息，请参阅 https://specifications.openehr.org/releases/RM/latest/data_types.html#_dv_quantity_class。">
+					hl7v2_mapping = <"OBX.2, OBX.5, OBX.6, OBX.7, OBX.8">
+					fhir_mapping = <"Observation.value[x]">
+				>
+				["at0003"] = <
+					text = <"备注">
+					description = <"关于分析物结果的，其他字段当中并未采集/反映的其他叙述。">
+					hl7v2_mapping = <"NTE.3">
+					fhir_mapping = <"Observation.note">
+				>
+				["at0004"] = <
+					text = <"参考范围指引">
+					description = <"关于参考范围是否适用于当前此项结果的补充建议，或者也可能含有关于当前此项结果是否在正常范围之内的文本型或编码文本型指引。">
+					comment = <"例如，“在针对相应年龄和性别的正常范围之内”。">
+				>
+				["at0005"] = <
+					text = <"结果状态">
+					description = <"当前分析物结果取值的状态。">
+					comment = <"这些取值经过了专门的选择，以匹配 HL7 FHIR 诊断报告资源之中的取值，而后者从历史上则源自 HL7v2 的做法。可以利用文本选项 'choice' 来使用其他的本地代码/术语。
+
+当前的数据元允许多次出现，以支持需要实现不止一种状态类型的用例场景。">
+					hl7v2_mapping = <"OBX.11">
+					fhir_mapping = <"Observation.status">
+				>
+				["at0006"] = <
+					text = <"结果状态时间">
+					description = <"就所记录的“结果状态”来说，当前分析物结果的发布日期和时间。">
+					hl7v2_mapping = <"OBX.19">
+					fhir_mapping = <"Observation.issued">
+				>
+				["at0014"] = <
+					text = <"分析物结果详情">
+					description = <"关于具体结果的进一步细节。">
+				>
+				["at0015"] = <
+					text = <"已登记">
+					description = <"实验室信息系统（LIS）当中已登记了当前的检验项目，但其目前还没有任何可用的结果/数据。">
+				>
+				["at0016"] = <
+					text = <"部分">
+					description = <"这是部分的（如初始的、临时的或初步的）检验结果：当前检验结果之中的数据可能并不完整或未经验证/确认。">
+				>
+				["at0017"] = <
+					text = <"初步">
+					description = <"已有经过核对/验证的早期结果可用，但并非所有结果都是最终结果。这属于是“部分”类的子类别。">
+				>
+				["at0018"] = <
+					text = <"最终">
+					description = <"当前的检验结果完整无缺并且经过了授权人员的验证/确认。">
+				>
+				["at0019"] = <
+					text = <"经过修正">
+					description = <"当前的结果是在其成为最终结果之后又经过修改的结果，且完整无缺，并经过了授权人员的验证/确认。属于是“经过改动”的子类别。">
+				>
+				["at0020"] = <
+					text = <"经过改动">
+					description = <"当前的结果是在其成为最终结果之后又经过修改的结果，且完整无缺，并经过了授权人员的验证/确认。换句话说，结果数据发生了变化。">
+				>
+				["at0021"] = <
+					text = <"经过增补">
+					description = <"在成为最终版本之后，对报告进行了修改，在其中增加了新的内容。原有的内容保持不变。属于是“经过改动”的子类别。">
+				>
+				["at0022"] = <
+					text = <"错误录入">
+					description = <"在之前的最终版本发布之后已撤回了当前的检验结果。">
+				>
+				["at0023"] = <
+					text = <"已取消">
+					description = <"当前此项结果不可用，因为该检验项目尚未开始或并未完成（有时也称为“中止”）。">
+				>
+				["at0024"] = <
+					text = <"分析物名称">
+					description = <"分析物结果的名称。">
+					comment = <"通常会在特化原始型中、在模板当中或在运行时提供当前数据元的取值，以反映实际的分析物。例如：“血清钠”、“血红蛋白”。强烈建议采用外部术语集加以编码，如 LOINC、NPU、SNOMED CT 或本地实验室[检验]术语集。">
+					hl7v2_mapping = <"OBX.3">
+					fhir_mapping = <"Observation.code">
+				>
+				["at0025"] = <
+					text = <"验证时间">
+					description = <"实验室的医疗保健职业人员验证当前分析物结果的日期和时间。">
+					comment = <"在许多司法管辖区域，都会假设认为结果状态数据元 'Result status' 之中包括了医疗验证/确认，即假设认为“最终”结果经过了医学验证/确认，而在其他的司法管辖区域，则会单独记录和报告该数据元。">
+				>
+				["at0026"] = <
+					text = <"标本">
+					description = <"当前分析物结果所使用的标本的标识。">
+					comment = <"在某些情况下，单个的实验室测试结果原始型当中会包含多个样本原始型 Specimen 和多个分析物结果原始型 “Analyte result”。在此类情况下，就需要利用当前标本数据元 Specimen 才能将结果与相应的标本正确地关联起来。">
+				>
+				["at0027"] = <
+					text = <"分析物结果序号">
+					description = <"当前的分析物结果在整个分析物结果序列当中的预定位置。">
+					comment = <"例如：'1'、'2'、'3'。当报告多项分析物结果时，当前数据元旨在明确分析物结果的报告顺序。">
+				>
+				["at0028"] = <
+					text = <"检验方法">
+					description = <"关于仅仅用于检验当前分析物时所采用的方法的描述。">
+					comment = <"如果检验方法适用于当前整个的组套/组合项目，则可以采用实验室检验结果原始型 OBSERVATION.laboratory_test_result 之中的检验方法数据元 'Test method' 来记录检验方法。">
+				>
+				["at0031"] = <
+					text = <"*Analysis performed time (en)">
+					description = <"*The date and time when the analyte result was performed in the laboratory by a healthcare practitioner. (en)">
+					comment = <"*Represents the actual analysis timestamp, independent of when the result is recorded or reported. (en)">
+				>
+				["at0032"] = <
+					text = <"*Accredited (en)">
+					description = <"*Indicates whether the analytical method used for this analyte is accredited. (en)">
+					comment = <"*Supports quality assurance and regulatory compliance by specifying whether the laboratory analysis was performed under an accredited method. (en)">
+				>
+			>
+		>
+	>

--- a/input/archetypes/openEHR-EHR-CLUSTER.laboratory_test_panel.v0.adl
+++ b/input/archetypes/openEHR-EHR-CLUSTER.laboratory_test_panel.v0.adl
@@ -1,0 +1,134 @@
+﻿archetype (adl_version=1.4; rm_release=1.1.0; uid=440253f1-61d9-49d3-ae27-58129bbeb6e0)
+	openEHR-EHR-CLUSTER.laboratory_test_panel.v0
+
+concept
+	[at0000]	-- Laboratory test panel
+language
+	original_language = <[ISO_639-1::en]>
+	translations = <
+		["de"] = <
+			language = <[ISO_639-1::de]>
+			author = <
+				["name"] = <"Anneka Sargeant">
+				["organisation"] = <"UMG Göttingen">
+				["email"] = <"anneka.sargeant@med.uni-goettingen.de">
+			>
+		>
+		["nb"] = <
+			language = <[ISO_639-1::nb]>
+			author = <
+				["name"] = <"Silje Ljosland Bakke">
+				["organisation"] = <"Nasjonal IKT HF">
+			>
+		>
+	>
+description
+	original_author = <
+		["name"] = <"Ian McNicoll">
+		["organisation"] = <"freshEHR Clinical Informatics, UK">
+		["email"] = <"ian@freshehr.com">
+		["date"] = <"2015-07-20">
+	>
+	details = <
+		["de"] = <
+			language = <[ISO_639-1::de]>
+			purpose = <"Dient zur Erfassung von Laborergebnissen als Panel/Profil von Einzelresultaten. Verbreitet im medizinischen Labor, z.B. bei biochemischen, hämatologischen und immunologischen Tests.">
+			use = <"Dient zur Erfassung von Laborergebnissen als Panel/Profil von Einzelresultaten. Verbreitet im medizinischen Labor, z.B. bei biochemischen, hämatologischen und immunologischen Tests. Wird normalerweise als abgeleitete Klasse von OBSERVATION.laboratory_test_result verwendet.
+
+Wenn komplexere Resultatsstrukturen erforderlich sind, kann es hilfreich sein, den Archetyp zu spezialisieren oder durch einen anderen zu ersetzen.">
+			keywords = <"Labor, Pathologie, Panel, Profil", ...>
+			misuse = <"Nicht zur Erfassung von makroskopischen/mikroskopischen Resultaten in der anatomischen Pathologie.">
+		>
+		["nb"] = <
+			language = <[ISO_639-1::nb]>
+			purpose = <"For å registrere laboratorieanalyser som en enkeltverdi eller i en analysepakke.">
+			use = <"For å registrere laboratorieanalyser som en enkeltverdi eller i en analysepakke. Brukes normalt i arketypen OBSERVATION.laboratory_test.
+
+Navnene på elementene Laboratoriesvar/Svarverdi vil ordinært erstattes i en templat elller applikasjon med navnet på den spesifikke analysen. f.eks. \"Hemoglobin\", og ofte kodet med en terminologi som NLK, SNOMED CT eller LOINC.
+
+Der det kreves mer komplekse svarmønstre kan det være nødvendig å spesialisere denne arketypen, eller erstatte den med en annen.">
+			keywords = <"laboratorie", "panel", "batteri", "analytt", "analyse", "svar", "resultat", "pakke">
+			misuse = <"Skal ikke brukes til å registrere funn ved patologiundersøkelser.">
+		>
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"To record laboratory test results in a panel/battery/profile structure common to clinical pathology testing for example biochemistry, haematology and immunology.">
+			use = <"To record laboratory test results in a panel/battery structure common to clinical pathology testing  biochemistry, haematology and immunology. Normally used in conjunction with a parent 
+OBSERVATION.laboratory_test_result.
+
+Where other more complex result patterns are required it may be helpful to specialise this archetype or substitute another.">
+			keywords = <"laboratory", "pathology", "panel", "battery", "profile">
+			misuse = <"Not to be used to record Anatomical pathology macroscopic/microscopic findings.">
+			copyright = <"© openEHR Foundation">
+		>
+	>
+	lifecycle_state = <"in_development">
+	other_contributors = <"Heather Leslie, Ocean Informatics, Australia", "Nasjonal IKT, Norway">
+	other_details = <
+		["licence"] = <"This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/.">
+		["custodian_organisation"] = <"openEHR Foundation">
+		["references"] = <"Pathology Test Result, Draft Archetype [Internet]. Australian Digital Health Agency, Australian Digital Health Agency Clinical Knowledge Manager [cited: 2017-06-27]. Available from: http://dcm.nehta.org.au/ckm/#showArchetype_1013.1.839 
+
+Pathology (Data Specifications) Version 1.0 [Internet]. Sydney, Australia: National E-Health Transition Authority; 2007 May 29 [cited 2011 Jul 11]; Available at http://www.nehta.gov.au/component/docman/doc_download/962-pathology-v10
+
+Laboratory Technical Framework, Volume 3: Content, Revision 3.0 [Internet]. USA: IHE International; 2011 May 19; [cited 2011 Jul 11]. Available from: http://www.ihe.net/Technical_Framework/index.cfm#laboratory
+
+Hl7 FHIR Observation resource: HL7 [Internet]; [cited 2017 Jun 27]. Available from http://www.hl7.org/implement/standards/fhir/observation.html">
+		["original_namespace"] = <"org.openehr">
+		["original_publisher"] = <"openEHR Foundation">
+		["custodian_namespace"] = <"org.openehr">
+		["MD5-CAM-1.0.1"] = <"16ACB1FB473C63B4BC99E2DDF970BED2">
+		["build_uid"] = <"0d4d4802-dd56-45e3-accf-96ac97c242b3">
+		["revision"] = <"0.0.1-alpha">
+	>
+
+definition
+	CLUSTER[at0000] matches {	-- Laboratory test panel
+		items cardinality matches {1..*; unordered} matches {
+			allow_archetype CLUSTER[at0013] occurrences matches {0..*} matches {	-- Panel detail
+				include
+					archetype_id/value matches {/openEHR-EHR-CLUSTER\.laboratory_test_panel(-[a-zA-Z0-9_]+)*\.v0|openEHR-EHR-CLUSTER\.laboratory_test_analyte(-[a-zA-Z0-9_]+)*\.v0|openEHR-EHR-CLUSTER\.specimen(-[a-zA-Z0-9_]+)*\.v0/}
+			}
+		}
+	}
+
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Laboratory test panel">
+					description = <"Laboratory test result as a panel/battery/profile structure common to clinical pathology testing.">
+				>
+				["at0013"] = <
+					text = <"Panel detail">
+					description = <"Further details including the individual analytes, specimen for the panel or a further nested panel.">
+				>
+			>
+		>
+		["nb"] = <
+			items = <
+				["at0000"] = <
+					text = <"*Laboratory test panel(en)">
+					description = <"*Laboratory test result as a panel/battery format common to clinical pathology testing.(en)">
+				>
+				["at0013"] = <
+					text = <"*Panel detail(en)">
+					description = <"*Further details including the individual analytes, specimen for the panel or a further nested panel.(en)">
+				>
+			>
+		>
+		["de"] = <
+			items = <
+				["at0000"] = <
+					text = <"Labortest-Panel">
+					description = <"Laborergebnis als Panel/Profil von Einzelresultaten. Verbreitet im medizinischen Labor.">
+				>
+				["at0013"] = <
+					text = <"Panel-Detail">
+					description = <"Weitere Details zum Panel, einschließlich der einzelnen Analyte, Proben für das Panel oder weitere, verschachtelte Panels.">
+				>
+			>
+		>
+	>

--- a/input/archetypes/openEHR-EHR-OBSERVATION.laboratory_test_result.v1.adl
+++ b/input/archetypes/openEHR-EHR-OBSERVATION.laboratory_test_result.v1.adl
@@ -1,0 +1,3033 @@
+﻿archetype (adl_version=1.4; rm_release=1.1.0; uid=90225e36-20a8-403a-8172-77e53b9990b2)
+	openEHR-EHR-OBSERVATION.laboratory_test_result.v1
+
+concept
+	[at0000]	-- Laboratory test result
+language
+	original_language = <[ISO_639-1::en]>
+	translations = <
+		["de"] = <
+			language = <[ISO_639-1::de]>
+			author = <
+				["name"] = <"Sarah Ballout">
+				["organisation"] = <"MHH-Hannover">
+				["email"] = <"ballout.sarah@mh-hannover.de">
+			>
+		>
+		["sv"] = <
+			language = <[ISO_639-1::sv]>
+			author = <
+				["name"] = <"Linda Aulin, Åsa Skagerhult, Linda Aulin Lundeqvist">
+				["organisation"] = <"Region Stockholm, Region Östergötland, Karolinska University Hospital, Region Stockholm">
+				["email"] = <"linda.aulin@sll.se, linda.aulin@regionstockholm.se, asa.skagerhult@regionostergotland.se, linda.aulin-lundeqvist@regionstockholm.se">
+			>
+		>
+		["fi"] = <
+			language = <[ISO_639-1::fi]>
+			author = <
+				["name"] = <"Riikka Lahtela">
+				["organisation"] = <"Istekki">
+				["email"] = <"riikka.lahtela@istekki.fi">
+			>
+			other_details = <
+				["other_contributors"] = <"Henri Huttunen, UNA Oy, Finland; Heidi Koikkalainen, FreshEHR">
+			>
+		>
+		["nb"] = <
+			language = <[ISO_639-1::nb]>
+			author = <
+				["name"] = <"Vebjørn Arntzen/Silje Ljosland Bakke/Liv Laugen">
+				["organisation"] = <"Oslo universitetssykehus HF/Nasjonal IKT HF/Oslo universitetssykehus, Norway">
+			>
+		>
+		["pt-br"] = <
+			language = <[ISO_639-1::pt-br]>
+			author = <
+				["name"] = <"Vladimir Pizzo">
+				["organisation"] = <"Clínica Parente Pizzo">
+				["email"] = <"vrppizzo@gmail.com">
+			>
+		>
+		["ar-sy"] = <
+			language = <[ISO_639-1::ar-sy]>
+			author = <
+				["name"] = <"Mona Saleh">
+			>
+		>
+		["it"] = <
+			language = <[ISO_639-1::it]>
+			author = <
+				["name"] = <"Alessandro Sulis/Francesca Frexia/Cecilia Mascia">
+				["organisation"] = <"CRS4 - Center for advanced studies, research and development in Sardinia, Pula (Cagliari), Italy">
+				["email"] = <"alessandro.sulis@crs4.it/francesca.frexia@crs4.it/cecilia.mascia@crs4.it">
+			>
+		>
+		["zh-cn"] = <
+			language = <[ISO_639-1::zh-cn]>
+			author = <
+				["name"] = <"Lin Zhang">
+				["organisation"] = <"Freelancer">
+				["email"] = <"linforest@163.com">
+			>
+			accreditation = <"N/A">
+		>
+		["nl"] = <
+			language = <[ISO_639-1::nl]>
+			author = <
+				["name"] = <"Joost Holslag">
+				["organisation"] = <"Nedap">
+				["email"] = <"joost.holslag@nedap.com">
+			>
+			accreditation = <"MD">
+		>
+		["es"] = <
+			language = <[ISO_639-1::es]>
+			author = <
+				["name"] = <"Julio de Sosa">
+				["organisation"] = <"Servei Català de la Salut">
+				["email"] = <"juliodesosa@catsalut.cat">
+			>
+		>
+		["ca"] = <
+			language = <[ISO_639-1::ca]>
+			author = <
+				["name"] = <"Julio de Sosa">
+				["organisation"] = <"Servei Català de la Salut">
+				["email"] = <"juliodesosa@catsalut.cat">
+			>
+		>
+	>
+description
+	original_author = <
+		["name"] = <"Ian McNicoll">
+		["organisation"] = <"freshEHR Clinical Informatics">
+		["email"] = <"ian@freshehr.com">
+		["date"] = <"2015-07-20">
+	>
+	details = <
+		["de"] = <
+			language = <[ISO_639-1::de]>
+			purpose = <"Zur Dokumentation des Ergebnisses - einschließlich der Befunde und der Interpretation des Labors - einer Untersuchung, die an Proben durchgeführt wurde, die von einer Einzelperson stammen oder mit dieser Person zusammenhängen.">
+			use = <"Zur Dokumentation des Ergebnisses - einschließlich der Befunde und der Interpretation des Labors - einer Untersuchung, die an Proben durchgeführt wurde, die von einer Einzelperson stammen oder mit dieser Person zusammenhängen. Dies geschieht in der Regel in einem Labor, kann aber auch in anderen Bereichen, wie z.B. am Point of Care, durchgeführt werden. 
+
+Dieser Archetyp soll das Ergebnis einer erforderlichen Einzeluntersuchung abdecken, bei der die Probe(n) über ein Einzelverfahren gesammelt werden, und kann mehrere Ergebnisse zu Analyten oder andere Komponenten enthalten. Beispiele hierfür könnte das „Vollblutbild“ sein, das ein separates Analyseergebnis für die Zählung jedes Blutzelltyps liefert, oder „Nierenbiopsie nicht neoplastisch“, das Ergebnisse aus der Mikroskopie, Immunhistochemie und Elektronenmikroskopie liefern würde.
+
+Dieser Archetyp wurde als Framework konzipiert, das in der Regel um CLUSTER-Archetypen erweitert wird, um eine angemessene Aufzeichnung spezifischer Labor-Testergebnismuster zu ermöglichen. Einschließlich aber nicht beschränkt auf: Tests für Biochemie, Hämatologie, Immunologie und Blutspendendienste etc. sowie spezifische Muster für die besonderen Anforderungen an Mikrobiologie und anatomische Pathologie. Wenn die in Auftrag gegebenen Tests oder Untersuchungen nicht gewöhnlich in einer benannten Gruppe oder einem benannten Panel zusammengehören, wird jedes Testergebnis in der Regel durch separate Instanzen dieses Archetyps dargestellt. Es gibt jedoch erhebliche Unterschiede in der tatsächlichen Berichts-/Messaging-Praxis, und dieser Archetyp/diese verwandten Archetypen sind so konzipiert, dass sie mit diesen Abweichungen umgehen können. 
+
+Dieser Archetyp unterstützt mehrere Ansätze zur Erfassung von Proben und spiegelt die aktuelle, sehr unterschiedliche Praxis wieder. Ein Laborergebnis hat einen hohen Grad an Übereinstimmung mit einer HL7 FHIR Diagnoseberichtsquelle. 
+
+Es wird erwartet, dass ein oder mehrere Exemplare dieses Archetyps oder dieser Archetypfamilie an einen anfragenden Arzt innerhalb eines Labordokuments zurückgeschickt werden, das COMPOSITION.report_result Archetyp, oder ähnliche und andere relevante ENTRY Archetypen.
+
+Die Erfassung von Störfaktoren kann inkonsistent sein, weil es oft vom Quelllabor und von den klinischen Informationen, die angefordert worden, abhängt. Im State-Abschnitt des Archetyps gibt es ein einfaches Datenelement \"Confounding factors\", das optional ist und als eine Möglichkeit wiederholt werden kann, eine Vielzahl von einfachen Faktoren zu erfassen, die explizit gemacht werden müssen, da sie die Interpretation der Ergebnisse beeinflussen können. Wenn die Störfaktoren komplexer sind, kann es sinnvoll sein, einen lokalen/gemeinsamen CLUSTER-Archetyp zu erstellen, der im SLOT \"Confounding factors details\" ergänzt werden kann. 
+Hinweis 1: Bekannte oder erforderliche Voraussetzungen, wie z.B. \"Fasten\" oder \"Tag 1 des Menstruationszyklus\", sollten im Datenelement \"Probenbedingungen\" im Archetyp CLUSTER.Probe, verschachtelt innerhalb des OBSERVATION Archetypes, angegeben werden.
+Hinweis 2: Bekannte Probleme bei der Probenentnahme oder Behandlung, wie z.B. \"Probe hämolysiert\" oder \"verlängerter Gebrauch von Tourniquet\", sollten unter \"Probenqualität\" im Archetyp CLUSTER.Probe, verschachtelt innerhalb des OBSERVATION Archetypes, angegeben werden.
+
+Werden vom Labor \"Reflextests\" durchgeführt, können diese gemäß den US/FHIR-Richtlinien (siehe https://www.hl7.org/fhir/2015may/uslabreportguide.html) oder anderen lokalen Richtlinien durchgeführt werden. Zum Beispiel eine der folgenden Punkte.... 
+1. Protokollierung der Reflextestergebnisse zusätzliche \"Testergebnisse\" innerhalb derselben \"openEHR-EHROBSERVATION.Laborergebnis\". 
+2. Protokollierung der Reflextestergebnisse zusätzliche \"Testergebnisse\" innerhalb derselben \"openEHR-EHROBSERVATION.Laborergebnis\", verweisen Sie aber über \"Testerforderungsdetails\" auf den ursprünglichen Labortestantrag. 
+3. Protokollierung der Reflextestergebnisse zusätzliche \"Testergebnisse\" innerhalb derselben \"openEHR-EHROBSERVATION.Laborergebnis\" festhalten, aber über \"Testerforderungsdetails\" auf einen neuen Labortestantrag sowie den ursprünglichen Labortestantrag verweisen.
+
+
+
+
+
+">
+			keywords = <"Labor", "Pathologie", "Biochemie", "Hämatologie", "Mikrobiologie", "Immunologie", "Laboratorium", "anatomisch", "chemisch", "klinisch", "Immunpathologie", "Zytologie", "Histopathologie", "Untersuchung", "Biopsie", "Probe", "forensisch", "genetisch bedingt", "Labormedizin", "Ergebnisse", "Analyse">
+			misuse = <"Nicht zur Dokumentation eines Autopsieberichts oder eines forensischen Berichts verwenden. Einzelne Proben, die bei einer Autopsie oder einem forensischen Bericht entnommen werden, können jedoch mit diesem Archetyp dargestellt werden. Für diese sind zusätzliche spezialisierte Archetypen erforderlich, um die Daten zu dokumentieren.
+
+Dieser Archetyp eignet sich zur Darstellung allgemeiner Labortestergebnisse, jedoch nicht für vollständige synoptische Berichte. Für diese sind zusätzliche spezialisierte Archetypen erforderlich, um die Daten zu dokumentieren.">
+		>
+		["sv"] = <
+			language = <[ISO_639-1::sv]>
+			purpose = <"För att registrera resultat, fynd och laboratoriets tolkning av en laboratorieundersökning utförd på provmaterial från en individ eller relaterad till individen.">
+			use = <"Används för att registrera resultatet, inklusive fynd och laboratoriets tolkning, av en laboratorieundersökning utförd på provmaterial från en individ eller relaterad till individen. Detta görs vanligtvis i ett laboratorium, men kan även göras i andra miljöer såsom patientnära analys vid provtagningstillfället.
+
+Denna arketyp är avsedd att täcka resultatet av en enda beställd undersökning där flera prov tas i ett enda förfarande och som kan innehålla flera analysresultat eller andra komponenter. 
+Exempel på detta kan inkludera \"fullständig blodstatus\", vilket skulle ge ett separat analysresultat för räkningen av varje typ av blodkropp, eller \"njurbiopsi - inget malignt\", vilket skulle ge resultat från mikroskopi, immunhistokemi och elektronmikroskopi.
+
+Denna arketyp är utformad för att utgöra ett ramverk som vanligtvis kommer att utökas med CLUSTER-arketyper för registrering och rapportering av specifika mönster för laboratorieresultat. Detta inkluderar analyser inom biokemi, klinisk kemi, hematologi, immunologi och transfusionstjänster samt specifika mönster för de unika behoven inom mikrobiologi och patologi. Om de beställda analyserna eller undersökningarna inte tillhör en namngiven grupp, ska varje testresultat normalt representeras med separata instanser av denna arketyp. Det finns dock stor variation i hur svarsrapportering sker och denna arketyp är utformad för att hantera den typen av variation.
+
+Den här arketypen stöder olika tillvägagångssätt för att kunna fånga den mångfald av analyser och metoder som finns tillgängliga. Ett resultat från ett laboratorium är idag i hög grad anpassat till HL7 FHIR-resursen Diagnostic Report.
+
+Det är troligt att hela eller delar av denna arketyp, tillsammans med relaterade arketyper, kommer att utgöra remissvar till remitterande läkare. Exempel på detta är COMPOSITION.report_result-arketypen eller motsvarande, och med relevanta ENTRY-arketyper.
+
+Denna arketyp stöder flera metoder för att registrera information om provmaterialet, vilket återspeglar de stora variationerna inom nuvarande praxis. Arketypen för laboratoriesvar har en hög grad av överensstämmelse med HL7 FHIR-resursen \"Diagnostic Report\".
+
+Registrering av möjliga felkällor görs i praktiken oftast inte på ett konsekvent sätt. Detta kan bero både på avsändarlaboratoriet och på den kliniska information som skickats med från den vårdpersonal som skickat förfrågan. I \"State\"-delen av arketypen finns det ett enkelt dataelement, \"Möjliga felkällor\", som är valfritt och kan återupprepas som ett sätt att registrera en mängd olika enkla faktorer som måste göras tydliga eftersom de kan påverka tolkningen av resultaten. Om möjliga felkällor är av det mer komplexa slaget, kan det vara lämpligt att skapa en CLUSTER-arketyp som kan användas i SLOT ''Möjliga felkällor''.
+
+Anmärkning 1: Kända förhållanden eller förutsättningar för provtagning, såsom \"fasta\" eller \"dag 1 i menstruationscykeln\", bör registreras i dataelementet \"Provtagningsförhållanden\" i arketypen CLUSTER.Specimen (Provmaterial) nästlad i denna OBSERVATION-arketyp.
+Anmärkning 2: Kända problem med provtagning eller hantering av prover, såsom \"hemolys\" eller \"förlängd användning av stas\", bör registreras i \"Provkvalitetsproblem\" -elementet i CLUSTER.Specimen-arketypen och nästlas i denna OBSERVATION-arketyp.
+
+Om laboratoriet ändrar analyser eller lägger till analyser som uppföljning kan dessa hanteras enligt riktlinjer från HL7 FHIR (https://www.hl7.org/fhir/2015may/uslabreport-guide.html), eller enligt lokala förfaranden. Till exempel något av följande:
+1. Registrera de ändrade analyserna/tilläggsanalyserna inom samma instans av denna arketyp.
+2. Registrera de ändrade analyserna/tilläggsanalyserna i en ny instans av denna arketyp, men hänvisa till den ursprungliga beställningen via \"Beställningsdetaljer\".
+3. Registrera de ändrade analyserna/tilläggsanalyserna i en ny instans av den här arketypen, men hänvisa till en ny beställning utöver den ursprungliga via \"Beställningsdetaljer\".
+
+">
+			keywords = <"labb", "lab", "patologi", "biokemi", "hematologi", "mikrobiologi", "immunologi", "laboratorium", "anatomisk", "kemisk", "klinisk", "klinisk kemi", "immunopatologi", "cytologi", "histopatologi", "test", "biopsi", "prov", "provmaterial", "rättsmedicin", "forensisk", "genetisk", "laboratoriemedicin", "resultat", "analys", "flödescytometri", "immunoflourescens">
+			misuse = <"Bör inte användas för att lagra en obduktionsrapport eller rättsmedicinsk undersökningsrapport, även om analysresultat för vissa provmaterial som tagits vid en obduktion kan representeras i denna arketyp. För att skapa den verkliga obduktions- eller kriminaltekniska rapporten måste man använda specialiserade arketyper.
+
+Denna arketyp är lämplig för att representera allmänna laboratoriesvar men är inte avsedd för sammanfattande rapporter, där specialiserade arketyper bör användas istället.">
+		>
+		["fi"] = <
+			language = <[ISO_639-1::fi]>
+			purpose = <"*To record the result, including findings and the laboratory's interpretation, of an investigation performed on specimens collected from an individual or related to that individual.(en)">
+			use = <"*Use to record the result, including findings and the laboratory's interpretation, of an investigation performed on specimens collected from an individual or related to that individual. This is typically done in a laboratory, but may be done in other environments such as at the point of care.
+
+This archetype is intended to cover the result of a single ordered investigation where the specimen(s) are collected as a single procedure, and may include multiple analyte results or other components. Examples of this could include 'Full blood count', which would yield a separate analyte result for the count of each type of blood cell, or 'kidney biopsy non-neoplastic', which would yield findings from microscopy, immunohistochemistry and electron microscopy.
+
+This archetype has been designed to be a framework that will usually be extended with CLUSTER archetypes to enable appropriate recording of specific laboratory test result patterns. This includes, but is not limited to, tests for biochemistry, haematology, immunology and transfusion services etc and specific patterns for the unique requirements for microbiology and anatomical pathology. If the ordered tests or investigations do not commonly belong together in a named group or panel, each test result would normally be represented using separate instances of this archetype. There is, however, considerable variation in actual reporting/messaging practice and this archetype/related archetypes are designed to handle such variation.
+
+This archetype supports multiple approaches to recording of specimen, reflecting current practice which varies enormously. A Laboratory test result has a high degree of alignment to an HL7 FHIR Diagnostic Report resource.
+
+It is anticipated that one or more instances of this archetype, or archetype family, will be sent back to a requesting clinician within a laboratory report document comprising COMPOSITION.report_result archetype, or similar, and other relevant ENTRY archetypes.
+
+The recording of confounding factors may be inconsistent, often depending on the analysing laboratory and on clinical information sent by the requester. In the State section of the archetype there is a simple 'Confounding factors' data element that is optional and can be repeated as one way to record a variety of simple factors that need to be made explicit as they may influence interpretation of the results. If the confounding factors are more complex, it may be appropriate to create a local/shared CLUSTER archetype that can be nested in the 'Confounding factors details' SLOT. 
+Note 1: Known or required pre-conditions, such as 'fasting' or 'Day 1 of menstrual cycle', should be reported in the 'Sampling conditions' data element in the CLUSTER.specimen archetype, nested within this OBSERVATION archetype.
+Note 2: Known issues with specimen collection or handling, such as 'sample haemolysed' or 'prolonged use of tourniquet' should be reported within 'Specimen quality' in the CLUSTER.specimen archetype, nested within this OBSERVATION archetype.
+
+Where 'reflex tests' are performed by the laboratory, these may be handled as per US/FHIR guidance (see https://www.hl7.org/fhir/2015may/uslabreport-guide.html) or other local policy. For example, one of the following ...
+1. Record the reflex test results additional 'Test findings' within the same 'openEHR-EHR-OBSERVATION.laboratory_test_result'
+2. Record the reflex test results as 'Test findings' within a new 'openEHR-EHR-OBSERVATION.laboratory_test_result' but refer to the original lab test request via 'Test request details'.
+3. Record the reflex test results as 'Test findings' within a new 'openEHR-EHR-OBSERVATION.laboratory_test_result' but reference a new lab test request as well as the original lab test request via 'Test request details'.(en)">
+			keywords = <"*lab(en)", "*pathology(en)", "*biochemistry(en)", "*haematology(en)", "*microbiology(en)", "*immunology(en)", "*laboratory(en)", "*anatomical(en)", "*chemical(en)", "*clinical(en)", "*immunopathology(en)", "*cytology(en)", "*histopathology(en)", "*test(en)", "*biopsy(en)", "*specimen(en)", "*forensic(en)", "*genetic(en)", "*laboratory medicine(en)", "*results(en)", "*analysis(en)">
+			misuse = <"*Not to be used to record an Autopsy or a Forensic report, although tests on some specimens that are taken in such situations may be represented using this archetype. For these, additional or specialised archetypes will be required to represent the data.
+
+This archetype is suitable for representation of general laboratory test results, but not intended to cover full synoptic reports. For these, additional specialising archetypes are required to represent the data.(en)">
+		>
+		["nb"] = <
+			language = <[ISO_639-1::nb]>
+			purpose = <"For å registrere resultat, funn og laboratoriets tolkning, av en laboratorieundersøkelse utført på prøvemateriale fra et individ eller relatert til individet.">
+			use = <"Brukes for å registrere resultat, funn og laboratoriets tolkning, av en laboratorieundersøkelse utført på prøvemateriale fra et individ eller relatert til individet. Dette utføres typisk i et laboratorium, men kan også gjøres i andre miljøer, som for eksempel ved pasientnær analysering.
+
+Denne arketypen er ment å dekke resultatet av én rekvirert undersøkelse der prøvene er tatt i én prosedyre, og som kan ha flere analyseresultater eller andre komponenter. Eksempler på dette kan være \"Differensialtelling av leukocytter\", som gir et separat resultat for antallet av hver type hvite blodceller, eller \"Nyrebiopsi ikke-neoplastisk\", som gir resultater fra mikroskopi, immunohistokjemi og elektronmikroskopi.
+
+Denne arketypen er laget for å være et rammeverk som vanligvis vil utvides med CLUSTER-arketyper for å få en hensiktsmessig registrering og rapportering av spesifikke mønstre for laboratorieresultater. Dette kan omfatte analyser og undersøkelser innen kjemi (medisinsk biokjemi, hematologi, immunologi og transfusjonsmedisin, med mer), samt spesifikke mønstre for de unike behovene innenfor mikrobiologi og patologi. Hvis de rekvirerte analysene eller undersøkelsene ikke tilhører en navngitt gruppe, vil hvert resultat normalt representeres ved en separat instans av denne arketypen. Imidlertid er det stor variasjon på hvordan svarrapportering/meldingsformidling skjer, og denne arketypen er designet for å ivareta disse variasjonene.
+
+Denne arketypen støtter flere tilnærminger til å registrere informasjon om prøvematerialet, noe som reflekterer de store variasjonene innenfor dagens praksis. Laboratoriesvar-arketypen har høy grad av samsvar med HL7 FHIR-ressursen \"Diagnostic Report\".
+
+Det forventes at en eller flere instanser av denne arketypen, eller arketypefamilen vil bli sendt tilbake til rekvirenten i en laboratoriesvarrapport, for eksempel i arketypen COMPOSITION.report_result eller tilsvarende, og sammen med relevante ENTRY-arketyper.
+
+Registrering av konfunderende faktorer gjøres i praksis ikke på en konsistent måte, og avhenger av avsenderlaboratoriet og av den kliniske informasjonen som ble sendt med fra rekvirenten. I \"State\"-delen av arketypen er det et valgfritt og repeterbart element for \"Konfunderende faktorer\" som kan brukes til å registrere enkle faktorer, som fordi de kan påvirke tolkningen av resultatet må registreres eksplisitt. Dersom de konfunderende faktorene er mer komplekse kan det være hensiktsmessig å lage en CLUSTER-arketype som kan brukes i SLOTet \"Strukturerte konfunderende faktorer\".
+NB 1: Kjente eller nødvendige forutsetninger, som for eksempel \"fastende\" eller \"dag 1 av menstruasjonssyklusen\" bør registreres i elementet \"Prøvetakingsforhold\" i arketypen CLUSTER.specimen, og nøstes inn i denne OBSERVATION-arketypen.
+NB 2: Kjente problemer med prøvetaking eller prøvehåndtering, som for eksempel \"hemolyse\" eller \"forlenget stase\" bør registreres i elementet \"Prøvekvalitet\" i arketypen CLUSTER.specimen, og nøstes inn i denne OBSERVATION-arketypen.
+
+Der laboratoriet endrer analyser eller legger til analyser som oppfølging, kan disse håndteres etter veilledning fra HL7 FHIR (https://www.hl7.org/fhir/2015may/uslabreport-guide.html), eller etter lokale prosedyrer. For eksempel en av følgende:
+1. Registrer de endrede analysene/tilleggsanalysene innenfor samme instans av denne arketypen.
+2. Registrer de endrede analysene/tilleggsanalysene i en ny instans av denne arketypen, men referer til den opprinnelige rekvisisjonen ved hjelp av \"Rekvisisjonsdetaljer\".
+3. Registrer de endrede analysene/tilleggsanalysene i en ny instans av denne arketypen, men referer til en ny rekvisisjon i tillegg til den opprinnelige rekvisisjonen, ved hjelp av \"Rekvisisjonsdetaljer\".">
+			keywords = <"medisinsk biokjemi", "medisinsk mikrobiologi", "medisinsk genetikk", "klinisk farmakologi", "patologi", "immunologi og transfusjonsmedisin", "laboratorie", "lab", "anatomisk", "prøve", "rettsmedisinsk", "laboratoriemedisin", "generell kjemi", "materiale", "prøvemateriale", "lokalisasjon", "undersøkelse", "analyse", "metode (analysemetode)", "laboratoriespesialitet", "blodprøve", "serum", "plasma", "fullblod", "analytt", "kapillærprøver", "venøse prøver", "arterielle prøver", "prøvetaking", "immunopatologi", "cytologi", "histopatologi", "biopsi", "preparat", "immunhistokjemi", "immuncytokjemi", "molekylærgenetiske analyser", "histologi", "cytologi", "cervixcytologi", "obduksjon", "flowcytometri", "molekylær patologi", "elektronmikroskopi", "neuropatologi", "frysesnitt", "punksjonscytologi", "makrobeskjæring", "makroskopisk undersøkelse", "mikrobiologi", "bakteriologi", "virologi", "serologi", "molekylærdiagnostikk", "parasittologi", "mykologi", "protozologi", "immunologi", "medisinsk immunologi", "transfusjonsmedisin", "immunhematologi", "transplantasjonsimmunologi", "cellulær immunologi", "ex vivo cellelaboratorium", "hormonanalyser", "endokrinologi", "blodbank", "blodkomponenter", "hematologi", "kjemisk", "klinisk", "kjemi", "klinisk kjemi", "klinisk biokjemi", "metabolsk molekylærbiologi", "homeostase og trombose", "koagulasjon", "klinisk farmakologi", "farmakologi", "doping analyser", "klinisk fysiologi", "toksikologi", "rusmiddelanalyse", "misbruksdiagnostikk", "genetisk", "genetikk", "HTS-diagnostikk", "genpaneler", "farmakogenetikk", "cancer cytogenetikk", "preparat", "rettsmedisinsk">
+			misuse = <"Skal ikke brukes for å lagre en sammenstilling etter obduksjon eller rettsmedisinsk undersøkelse, selv om prøver av noen prøvematerialer som blir tatt i en obduksjon kan bli representert i denne arketypen. For å lage selve obduksjons- eller den rettsmedisinske rapporten må man bruke spesialiserte arketyper.
+
+Denne arketypen er passende for å representere generelle laboratoriesvar, men er ikke ment å dekke komplette sammendragsrapporter (\"synoptic reports\") innenfor patologi. For disse trengs det i tillegg spesialiserte arketyper.">
+		>
+		["pt-br"] = <
+			language = <[ISO_639-1::pt-br]>
+			purpose = <"Documentar o resultado, incluindo achados e a interpretação do laboratório, de uma investigação realizada em amostras coletadas de um indivíduo ou relacionadas a esse indivíduo.">
+			use = <"Use para documentar o resultado, incluindo achados e a interpretação do laboratório, de uma investigação realizada em amostras coletadas de um indivíduo ou relacionadas a esse indivíduo. Isso normalmente é feito em um laboratório, mas pode ser feito em outros ambientes, como no próprio local de atendimento (point of care).
+
+Este arquétipo se destina a cobrir o resultado de uma única investigação solicitada, onde a(s) amostra(s) é(são) coletada(s) como um único procedimento e pode(m) incluir múltiplos resultados de analitos ou outros componentes. Exemplos disso podem incluir 'hemograma completo', que produziria um resultado separado (analito) para a contagem de cada tipo de célula sanguínea, ou 'biópsia renal não neoplásica', que produziria resultados de microscopia, imunohistoquímica e microscopia eletrônica.
+
+Este arquétipo foi projetado para ser uma estrutura que normalmente será ampliada com os arquétipos CLUSTER para permitir o registro apropriado de padrões de resultados de testes laboratoriais específicos. Isso inclui, mas não está limitado a, testes de bioquímica, hematologia, imunologia e serviços de transfusão, entre outros e padrões específicos para as solicitações de microbiologia e anatomia patológica. Se os testes ou investigações solicitados não pertencerem comumente a um grupo ou painel nomeado, cada resultado do teste será representado usando instâncias separadas deste arquétipo. Há, no entanto, uma variação considerável na prática real de relatórios/mensagens e esse arquétipo/arquétipos relacionados são projetados para lidar com essa variação.
+
+Este arquétipo oferece suporte a várias abordagens para o registro de espécimes, refletindo a prática atual que varia enormemente. Um resultado de teste de laboratório tem um alto grau de alinhamento com um recurso de relatório de diagnóstico HL7 FHIR (HL7 FHIR Diagnostic Report resource).
+
+É esperado que uma ou mais instâncias deste arquétipo, ou família de arquétipos, sejam enviadas de volta a um médico solicitante em um documento de relatório de laboratório compreendendo o arquétipo COMPOSITION.report_result, ou semelhante, e outros arquétipos de ENTRY relevantes.
+
+O registro de fatores de confusão pode ser inconsistente, geralmente dependendo do laboratório de análise e das informações clínicas enviadas pelo solicitante. Na seção Estado (State) do arquétipo, há um elemento de dados simples de 'Fatores de confusão' que é opcional e pode ser repetido como uma forma de registrar uma variedade de fatores simples que precisam ser explicitados, pois podem influenciar a interpretação dos resultados. Se os fatores de confusão forem mais complexos, pode ser apropriado criar um arquétipo CLUSTER local/compartilhado que pode ser aninhado no SLOT 'Detalhes dos fatores de confusão'.
+Nota 1: Pré-condições conhecidas ou exigidas, como 'jejum' ou 'Dia 1 do ciclo menstrual', devem ser relatadas no elemento de dados 'Condições de amostragem' no arquétipo CLUSTER.specimen, contido neste arquétipo de OBSERVAÇÃO (OBSERVATION).
+Nota 2: Problemas conhecidos com a coleta ou manuseio de amostras, como 'amostra hemolisada' ou 'uso prolongado de torniquete', devem ser relatados em 'Qualidade da amostra' no arquétipo de CLUSTER.specimen, contido neste arquétipo de OBSERVAÇÃO (OBSERVATION).
+
+Onde 'testes de reflexo' são realizados pelo laboratório, eles podem ser realizados de acordo com a orientação dos US/FHIR (consulte https://www.hl7.org/fhir/2015may/uslabreport-guide.html) ou outra política local. Por exemplo, um dos seguintes ...
+1. Registre os resultados adicionais do teste de reflexo nos 'Resultados do teste' dentro do mesmo 'openEHR-EHR-OBSERVATION.laboratory_test_result'
+2. Registre os resultados do teste de reflexo como 'Resultados do teste' em um novo 'openEHR-EHR-OBSERVATION.laboratory_test_result', mas referencie à solicitação de teste de laboratório original em 'Detalhes da solicitação de teste'.
+3. Registre os resultados do teste de reflexo como 'Resultados do teste' em um novo 'openEHR-EHR-OBSERVATION.laboratory_test_result', mas referencie uma nova solicitação de teste de laboratório, bem como a solicitação de teste de laboratório original por meio de 'Detalhes da solicitação de teste'.">
+			keywords = <"lab", "laboratório", "patologia", "bioquímica", "hematologia", "microbiologia", "imunologia", "anatomia", "química", "clínico", "imunopatologia", "citologia", "histopatologia", "teste", "biópsia", "espécimen", "forense", "genético", "laboratório médico", "laboratório clínico", "resultados", "análises", "análises clínicas">
+			misuse = <"Não deve ser usado para registrar uma Autópsia ou Relatório Forense, embora os testes em alguns espécimes que são tirados em tais situações possam ser representados usando este arquétipo. Para estes fins, arquétipos adicionais ou especializados serão necessários.
+
+Este arquétipo é adequado para representação de resultados de testes laboratoriais gerais, mas não se destina a cobrir relatórios sinópticos completos. Para representar estes dados, arquétipos especializados adicionais são necessários.">
+		>
+		["ar-sy"] = <
+			language = <[ISO_639-1::ar-sy]>
+			purpose = <"لتسجيل نتيجة اختبار المعمل, و التي قد يتم استخدامها لتسجيل اختبار ذي قيمة واحدة, و عادة ما يتم بعد ذلك المزيد من التخصيص أو الوضع في قالب لتمثيل اختبار متعدد القيم أو رتل من الاختبارات.
+و يمثل هذا النموذج كوالد (أب) للتخصيصات الأخرى لاختبارات معملية أكثر تحديدا مثل الميكروبيولوجيا و الهيستوباثولوجيا.">
+			use = <"قد يستخدم لتسجيل نتيجة اختبار المعمل, و التي قد يتم استخدامها لتسجيل اختبار ذي قيمة واحدة, و عادة ما يتم بعد ذلك المزيد من التخصيص أو الوضع في قالب لتمثيل اختبار متعدد القيم أو رتل من الاختبارات.
+
+يتم بعد ذلك تقديم التقرير للطبيب السريري الذي قام بطلب الاختبار في سياق تقرير معملي متكامل.">
+			keywords = <"المعمل - المختبر", "الباثولوجيا - المرضية", "الكيمياء الحيوية", "الدمويات", "الميكروبيولوجيا", "المناعيات - علم المناعة">
+			misuse = <"قد تكون التخصيصات أكثر مناسبة للتقارير المركبة مثل حالات الميكروبيولوجيا أو الهيستوباثولوجيا.">
+			copyright = <"© openEHR Foundation">
+		>
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"To record the result, including findings and the laboratory's interpretation, of an investigation performed on specimens collected from an individual or related to that individual.">
+			use = <"Use to record the result, including findings and the laboratory's interpretation, of an investigation performed on specimens collected from an individual or related to that individual. This is typically done in a laboratory, but may be done in other environments such as at the point of care.
+
+This archetype is intended to cover the result of a single ordered investigation where the specimen(s) are collected as a single procedure, and may include multiple analyte results or other components. Examples of this could include 'Full blood count', which would yield a separate analyte result for the count of each type of blood cell, or 'kidney biopsy non-neoplastic', which would yield findings from microscopy, immunohistochemistry and electron microscopy.
+
+This archetype has been designed to be a framework that will usually be extended with CLUSTER archetypes to enable appropriate recording of specific laboratory test result patterns. This includes, but is not limited to, tests for biochemistry, haematology, immunology and transfusion services etc and specific patterns for the unique requirements for microbiology and anatomical pathology. If the ordered tests or investigations do not commonly belong together in a named group or panel, each test result would normally be represented using separate instances of this archetype. There is, however, considerable variation in actual reporting/messaging practice and this archetype/related archetypes are designed to handle such variation.
+
+This archetype supports multiple approaches to recording of specimen, reflecting current practice which varies enormously. A Laboratory test result has a high degree of alignment to an HL7 FHIR Diagnostic Report resource.
+
+It is anticipated that one or more instances of this archetype, or archetype family, will be sent back to a requesting clinician within a laboratory report document comprising COMPOSITION.report_result archetype, or similar, and other relevant ENTRY archetypes.
+
+The recording of confounding factors may be inconsistent, often depending on the analysing laboratory and on clinical information sent by the requester. In the State section of the archetype there is a simple 'Confounding factors' data element that is optional and can be repeated as one way to record a variety of simple factors that need to be made explicit as they may influence interpretation of the results. If the confounding factors are more complex, it may be appropriate to create a local/shared CLUSTER archetype that can be nested in the 'Confounding factors details' SLOT. 
+Note 1: Known or required pre-conditions, such as 'fasting' or 'Day 1 of menstrual cycle', should be reported in the 'Sampling conditions' data element in the CLUSTER.specimen archetype, nested within this OBSERVATION archetype.
+Note 2: Known issues with specimen collection or handling, such as 'sample haemolysed' or 'prolonged use of tourniquet' should be reported within 'Specimen quality' in the CLUSTER.specimen archetype, nested within this OBSERVATION archetype.
+
+Where 'reflex tests' are performed by the laboratory, these may be handled as per US/FHIR guidance (see https://www.hl7.org/fhir/2015may/uslabreport-guide.html) or other local policy. For example, one of the following ...
+1. Record the reflex test results additional 'Test findings' within the same 'openEHR-EHR-OBSERVATION.laboratory_test_result'
+2. Record the reflex test results as 'Test findings' within a new 'openEHR-EHR-OBSERVATION.laboratory_test_result' but refer to the original lab test request via 'Test request details'.
+3. Record the reflex test results as 'Test findings' within a new 'openEHR-EHR-OBSERVATION.laboratory_test_result' but reference a new lab test request as well as the original lab test request via 'Test request details'.">
+			keywords = <"lab", "pathology", "biochemistry", "haematology", "microbiology", "immunology", "laboratory", "anatomical", "chemical", "clinical", "immunopathology", "cytology", "histopathology", "test", "biopsy", "specimen", "forensic", "genetic", "laboratory medicine", "results", "analysis">
+			misuse = <"Not to be used to record an Autopsy or a Forensic report, although tests on some specimens that are taken in such situations may be represented using this archetype. For these, additional or specialised archetypes will be required to represent the data.
+
+This archetype is suitable for representation of general laboratory test results, but not intended to cover full synoptic reports. For these, additional specialising archetypes are required to represent the data.">
+			copyright = <"© openEHR Foundation">
+		>
+		["it"] = <
+			language = <[ISO_639-1::it]>
+			purpose = <"Registrare il risultato, compresi i riscontri e l'interpretazione del laboratorio, di un'indagine effettuata su campioni raccolti su un individuo o relativi a quell'individuo.">
+			use = <"Utilizzato per registrare il risultato, compresi i riscontri e l'interpretazione del laboratorio, di un'indagine effettuata su campioni raccolti su un individuo o relativi a quell'individuo. Questo è tipicamente fatto in un laboratorio, ma può essere fatto in altri ambienti, come ad esempio al punto di cura.
+
+Questo archetipo è inteso per coprire il risultato di una singola indagine ordinata in cui il campione o i campioni sono raccolti come un'unica procedura, e può includere risultati di analiti multipli o altri componenti. Esempi di ciò potrebbero includere l' \"emocromo completo\", che darebbe un risultato dell'analisi separato per il conteggio di ciascun tipo di cellula del sangue, o la \"biopsia renale non neoplastica\", che darebbe risultati da microscopia, immunoistochimica e microscopia elettronica.
+
+Questo archetipo è stato progettato per essere un quadro di riferimento che di solito viene esteso con archetipi CLUSTER per consentire la registrazione appropriata di specifici modelli di risultati di test di laboratorio. Questo include, ma non si limita ai test per la biochimica, l'ematologia, l'immunologia e i servizi trasfusionali, ecc. e pattern specifici per i requisiti specializzati per microbiologia e anatomia patologica. Se i test o le indagini ordinati non appartengono comunemente a un gruppo o a un panel, ogni risultato di test verrebbe normalmente rappresentato utilizzando istanze separate di questo archetipo. Vi è, tuttavia, una notevole variazione nella pratica effettiva di refertazione/comunicazione e questo archetipo e gli archetipi correlati sono progettati per gestire tale variazione.
+
+Questo archetipo supporta approcci multipli alla registrazione dei campioni, riflettendo la pratica corrente che varia enormemente. Il risultato di un test di laboratorio ha un alto grado di allineamento con la risorsa HL7 FHIR Diagnostic Report.
+
+Si prevede che una o più istanze di questo archetipo, o famiglia di archetipi, saranno inviate ad un clinico richiedente all'interno di un documento di rapporto di laboratorio che comprende l'archetipo COMPOSITION.report_result, o simile, e altri archetipi ENTRY rilevanti.
+
+La registrazione dei fattori di confusione può essere incoerente, spesso a seconda del laboratorio di analisi e delle informazioni cliniche inviate dal richiedente. Nella sezione Stato dell'archetipo c'è un semplice elemento (\"fattori di confondimento\"), che è facoltativo e può essere ripetuto come un modo per registrare una varietà di semplici fattori che devono essere resi espliciti in quanto possono influenzare l'interpretazione dei risultati. Se i fattori confondenti sono più complessi, può essere opportuno creare un archetipo CLUSTER locale o condiviso, che può essere annidato nello SLOT \"Dettagli dei fattori confondenti\".
+Nota 1: Le precondizioni conosciute o richieste, come il 'digiuno' o il 'Giorno 1 del ciclo mestruale', devono essere riportate nell'elemento di dati 'Condizioni di campionamento' dell'archetipo CLUSTER.specimen, annidato all'interno di questo archetipo OSSERVAZIONE.
+Nota 2: I problemi noti relativi alla raccolta o al trattamento dei campioni, come \"emolisi del campione\" o \"uso prolungato del laccio emostatico\", devono essere riportati in \"Qualità del campione\" nell'archetipo CLUSTER.specimen, annidato all'interno di questo archetipo OBSERVATION.
+
+Se i \"reflex test\" vengono eseguiti dal laboratorio, questi possono essere gestiti secondo le linee guida US/FHIR (vedi https://www.hl7.org/fhir/2015may/uslabreport-guide.html) o altre politiche locali. Ad esempio, uno dei seguenti ...
+1. Registrare i risultati addizionali dei reflex test come 'Risultati dei test' all'interno dello stesso 'openEHR-EHR-OBSERVATION.laboratory_test_result'.
+2. 2. Registrare i risultati del reflex test come 'Risultati del test' all'interno di un nuovo 'openEHR-EHR-OBSERVATION.laboratory_test_result', ma fare riferimento alla richiesta originale del test di laboratorio tramite 'Dettagli della richiesta di test'.
+3. 3. Registrare i risultati del reflex test come 'Risultati del test' all'interno di un nuovo 'openEHR-EHR-OBSERVATION.laboratory_test_result', ma fare riferimento alla nuova richiesta di test di laboratorio insieme alla richiesta originale di test di laboratorio tramite 'Dettagli della richiesta di test'.">
+			keywords = <"lab, patologia, biochimica, ematologia, microbiologia, immunologia, laboratorio, anatomia, chimica, clinica, immunopatologia, citologia, istopatologia, test, biopsia, campione, medicina legale, genetica, medicina di laboratorio, risultati, analisi", ...>
+			misuse = <"Da non utilizzare per registrare un'autopsia o un rapporto forense, anche se i test su alcuni campioni prelevati in tali situazioni possono essere rappresentati utilizzando questo archetipo. Per questi, saranno necessari archetipi aggiuntivi o specializzati per rappresentare i dati.
+
+Questo archetipo è adatto per la rappresentazione dei risultati generali dei test di laboratorio, ma non è destinato a coprire i rapporti sinottici completi. Per questi, sono necessari ulteriori archetipi specializzati per rappresentare i dati.">
+		>
+		["zh-cn"] = <
+			language = <[ISO_639-1::zh-cn]>
+			purpose = <"旨在记录对于从个人身上所采集的标本或者与该个人相关的标本进行的检验结果，包括结果所见/发现和实验室的解释。">
+			use = <"旨在用于记录对于从个人身上所采集的标本或者与该个人相关的标本进行检验的结果，包括结果所见/发现和实验室的解释。通常会在实验室中完成此项工作，但也可能会在其他环境下完成，如床旁一线。
+
+本原始型旨在涵盖医嘱/申请所开立的单个检验项目的结果，其中采用的是单项操作所采集的标本（一份或多份），并且还可能包括多项分析物结果或若干其他的成分/组成部分。此类的例子可能包括“全血细胞计数”，其中会分别产生关于每种类型血细胞计数的，单独的分析物结果；又如“非肿瘤肾活检”，其中可能会产生显微镜检查、免疫组织化学检查和电子显微镜检查的结果。
+
+本原始型在设计上已经成为一种框架，通常会借助于群簇型原始型（CLUSTER）对其加以扩展，以便能够恰当地记录特定的实验室检验结果模式。其中包括但不仅限于生物化学、血液学、免疫学和输血服务等方面的检验项目，以及针对微生物学和解剖病理学方面独特要求的特定模式。如果医嘱/申请所开立的检验项目通常并不属于具名的组合或组套，正常情况下则利用本原始型的单独实例来表达每项检验结果。不过，实际的报告/消息传递实践存在着相当大的差异，而本原始型及其相关的原始型则正是旨在应对此类的变化。
+
+本原始型可支持多种的标本记录方法，反映了当前差异巨大的实践。实验室检验结果与 HL7 FHIR 诊断报告资源高度一致。
+
+预计一般会将本原始型或原始型家族的一个或多个实例包含在由组合式文书型报告结果原始型（COMPOSITION.report_result）或类似的原始型以及若干其他相关的条目型原始型（ENTRY）所构成的实验室检验报告文档之中，回报给作为申请方的临床医生。
+
+混杂因素的记录可能会缺乏一致性，且通常取决于分析实验室，以及申请方所发送的临床信息。在本原始型的状态（State） 之中，有一个简单的可选型混杂因素数据元“Confounding factors”，可以将其重复用作记录各种需要予以明确的简单因素的一种方式，因为这些因素可能会影响对于结果的解释。如果混杂因素较为复杂，则可能适合创建一个可以嵌套在混杂因素详细信息槽位“Confounding factors details”之中的本地/共享性群簇型原始型。
+
+注 1：对于已知或必需的前提条件，如“禁食”或“月经周期的第1天”，应当将其嵌套在这个观察型原始型之中的群簇型标本原始型（CLUSTER.specimen）里的采样条件数据元“Sampling conditions”中加以报告。
+
+注 2：对于标本采集或处理方面的已知问题，如“标本溶血”或“止血带使用时间过长”，应当将其嵌套在这个观察型原始型之中的群簇型标本原始型（CLUSTER.specimen）里的标本质量数据元“Specimen quality”中加以报告。
+
+如果实验室进行的是“伺机追加型检验项目”（reflex tests），则可以根据美国基于 FHIR 的检验报告指南（参见 https://www.hl7.org/fhir/2015may/uslabreport-guide.html）或其他当地政策来进行处理，如下列情况之一：
+
+1. 在同一个观察型实验室检验结果原始型“openEHR-EHR-OBSERVATION.laboratory_test_result”当中将若干的伺机追加型检验项目结果记录为额外的“检验结果所见/发现”
+2. 将若干的伺机追加型检验项目结果记录为新的观察型实验室检验结果原始型“openEHR-EHR-OBSERVATION.laboratory_test_result”之中的“检验结果所见/发现”，而同时又利用检验项目申请详情槽位“Test request details”来引用原始的实验室检验申请。
+3. 将若干的伺机追加型检验项目结果记录为新的观察型实验室检验结果原始型“openEHR-EHR-OBSERVATION.laboratory_test_result”之中的“检验结果所见/发现”，而同时又利用检验项目申请详情槽位“Test request details”来引用新的实验室检验项目申请以及原始的实验室检验申请。">
+			keywords = <"实验室", "医学实验室", "临床实验室", "中心实验室", "检验科", "化验室", "化验科", "病理学", "检验医学", "检验", "医学检验", "临床检验医学", "临床检验", "生物化学", "生化", "血液学", "微生物学", "免疫学", "解剖学", "化学", "临床", "免疫病理学", "细胞学", "组织病理学", "试验", "试验项目", "检验项目", "化验项目", "报告项目", "活组织检查", "活检", "标本", "样本", "样品", "试样", "法医学", "遗传学", "结果", "分析">
+			misuse = <"并非旨在用于记录尸检或法医报告，尽管在这种情况下可以采用本原始型来表达针对某些标本的检验项目。对于此类的项目，将需要额外的或专门的原始型来表达相应的数据。
+
+本原始型适用于表示一般实验室检验结果，但并非旨在用于涵盖/表达完整的概要报告（synoptic report）。对于此类的情况，将需要额外的或专门的原始型来表达相应的数据。">
+		>
+		["nl"] = <
+			language = <[ISO_639-1::nl]>
+			purpose = <"Voor het vastleggen van de uitslag, inclusief bevindingen en de interpretatie van het laboratorium, van een onderzoek uitgevoerd op een specimen van een individu of gerelateerd aan een individu.">
+			use = <"*Use to record the result, including findings and the laboratory's interpretation, of an investigation performed on specimens collected from an individual or related to that individual. This is typically done in a laboratory, but may be done in other environments such as at the point of care.
+
+This archetype is intended to cover the result of a single ordered investigation where the specimen(s) are collected as a single procedure, and may include multiple analyte results or other components. Examples of this could include 'Full blood count', which would yield a separate analyte result for the count of each type of blood cell, or 'kidney biopsy non-neoplastic', which would yield findings from microscopy, immunohistochemistry and electron microscopy.
+
+This archetype has been designed to be a framework that will usually be extended with CLUSTER archetypes to enable appropriate recording of specific laboratory test result patterns. This includes, but is not limited to, tests for biochemistry, haematology, immunology and transfusion services etc and specific patterns for the unique requirements for microbiology and anatomical pathology. If the ordered tests or investigations do not commonly belong together in a named group or panel, each test result would normally be represented using separate instances of this archetype. There is, however, considerable variation in actual reporting/messaging practice and this archetype/related archetypes are designed to handle such variation.
+
+This archetype supports multiple approaches to recording of specimen, reflecting current practice which varies enormously. A Laboratory test result has a high degree of alignment to an HL7 FHIR Diagnostic Report resource.
+
+It is anticipated that one or more instances of this archetype, or archetype family, will be sent back to a requesting clinician within a laboratory report document comprising COMPOSITION.report_result archetype, or similar, and other relevant ENTRY archetypes.
+
+The recording of confounding factors may be inconsistent, often depending on the analysing laboratory and on clinical information sent by the requester. In the State section of the archetype there is a simple 'Confounding factors' data element that is optional and can be repeated as one way to record a variety of simple factors that need to be made explicit as they may influence interpretation of the results. If the confounding factors are more complex, it may be appropriate to create a local/shared CLUSTER archetype that can be nested in the 'Confounding factors details' SLOT. 
+Note 1: Known or required pre-conditions, such as 'fasting' or 'Day 1 of menstrual cycle', should be reported in the 'Sampling conditions' data element in the CLUSTER.specimen archetype, nested within this OBSERVATION archetype.
+Note 2: Known issues with specimen collection or handling, such as 'sample haemolysed' or 'prolonged use of tourniquet' should be reported within 'Specimen quality' in the CLUSTER.specimen archetype, nested within this OBSERVATION archetype.
+
+Where 'reflex tests' are performed by the laboratory, these may be handled as per US/FHIR guidance (see https://www.hl7.org/fhir/2015may/uslabreport-guide.html) or other local policy. For example, one of the following ...
+1. Record the reflex test results additional 'Test findings' within the same 'openEHR-EHR-OBSERVATION.laboratory_test_result'
+2. Record the reflex test results as 'Test findings' within a new 'openEHR-EHR-OBSERVATION.laboratory_test_result' but refer to the original lab test request via 'Test request details'.
+3. Record the reflex test results as 'Test findings' within a new 'openEHR-EHR-OBSERVATION.laboratory_test_result' but reference a new lab test request as well as the original lab test request via 'Test request details'.(en)">
+			misuse = <"*Not to be used to record an Autopsy or a Forensic report, although tests on some specimens that are taken in such situations may be represented using this archetype. For these, additional or specialised archetypes will be required to represent the data.
+
+This archetype is suitable for representation of general laboratory test results, but not intended to cover full synoptic reports. For these, additional specialising archetypes are required to represent the data.(en)">
+		>
+		["es"] = <
+			language = <[ISO_639-1::es]>
+			purpose = <"Registrar el resultado, incluidas las conclusiones y la interpretación del laboratorio, de una investigación realizada con muestras recogidas de un individuo o relacionadas con él.">
+			use = <"Se utiliza para registrar el resultado, incluidos los hallazgos y la interpretación del laboratorio, de una investigación realizada en muestras recolectadas de un individuo o relacionadas con ese individuo. Esto normalmente se hace en un laboratorio, pero se puede hacer en otros entornos, como en el lugar de atención.
+
+Este arquetipo pretende cubrir el resultado de una única investigación ordenada en la que las muestras se recogen como un único procedimiento y puede incluir múltiples resultados de analitos u otros componentes. Ejemplos de esto podrían incluir un \"conteo sanguíneo completo\", que arrojaría un resultado de analito separado para el recuento de cada tipo de célula sanguínea, o una \"biopsia renal no neoplásica\", que arrojaría resultados mediante microscopía, inmunohistoquímica y microscopía electrónica.
+
+Este arquetipo ha sido diseñado para ser un borrador que generalmente se irá ampliando con arquetipos CLUSTER para permitir el registro apropiado de patrones de resultados de pruebas de laboratorio específicos. Esto incluye, entre otros, pruebas de bioquímica, hematología, inmunología y servicios de transfusión, etc., y patrones específicos para los requisitos únicos de microbiología y anatomía patológica. Si las pruebas o investigaciones solicitadas no están englobadas en ningún grupo, cada resultado de la prueba normalmente se representaría utilizando instancias separadas de este arquetipo. Sin embargo, existe una variación considerable en la práctica real de informes/mensajería y este arquetipo/arquetipos relacionados están diseñados para manejar dicha variación.
+
+Este arquetipo admite múltiples enfoques para el registro de muestras, lo que refleja la práctica actual que varía enormemente. El resultado de una prueba de laboratorio tiene un alto grado de alineación con un recurso de Informe de diagnóstico HL7 FHIR.
+
+Se prevé que una o más instancias de este arquetipo, o familia de arquetipos, se enviarán de vuelta al médico solicitante dentro de un documento de informe de laboratorio que comprenda el arquetipo COMPOSITION.report_result, o similar, y otros arquetipos ENTRY relevantes.
+
+El registro de factores de confusión puede ser inconsistente, dependiendo a menudo del laboratorio analizador y de la información clínica enviada por el solicitante. En la sección Estado del arquetipo hay un elemento de datos simple de 'Factores de confusión', que es opcional y puede repetirse como una forma de registrar una variedad de factores simples que deben hacerse explícitos, ya que pueden influir en la interpretación de los resultados. Si los factores de confusión son más complejos, puede ser apropiado crear un arquetipo de tipo CLUSTER local/compartido, que pueda anidarse en el SLOT 'Detalles de los factores de confusión'.
+Nota 1: Las condiciones previas conocidas o requeridas, como \"ayuno\" o \"Día 1 del ciclo menstrual\", deben informarse en el elemento de datos \"Condiciones de muestreo\" en el arquetipo CLUSTER.specimen, anidado dentro de este arquetipo OBSERVATION.
+Nota 2: Los problemas conocidos con la recolección o manipulación de muestras, como \"muestra hemolizada\" o \"uso prolongado de torniquete\", deben informarse en \"Calidad de la muestra\" en el arquetipo CLUSTER.specimen, anidado dentro de este arquetipo OBSERVATION.
+
+Cuando el laboratorio realiza \"pruebas de reflejos\", estas pueden manejarse según la guía US/FHIR (consulte https://www.hl7.org/fhir/2015may/uslabreport-guide.html) u otra política local. Por ejemplo, uno de los siguientes...
+1. Registre los resultados de la prueba reflejo adicional 'Resultados de la prueba' dentro del mismo 'openEHR-EHR-OBSERVATION.laboratory_test_result'
+2. Registre los resultados de la prueba reflejo, tales como 'Resultados de la prueba', dentro de un nuevo 'openEHR-EHR-OBSERVATION.laboratory_test_result' pero consulte la solicitud de prueba de laboratorio original a través de 'Detalles de la solicitud de prueba'.
+3. Registre los resultados de la prueba reflejo, tales como como 'Resultados de la prueba' dentro de un nuevo 'openEHR-EHR-OBSERVATION.laboratory_test_result' pero haga referencia a una nueva solicitud de prueba de laboratorio, así como a la solicitud de prueba de laboratorio original a través de 'Detalles de la solicitud de prueba'.">
+			keywords = <"laboratorio", "patología", "bioquímica", "hematología", "microbiología", "inmunología", "anatómico", "químico", "clínico", "inmunopatología", "citología", "histopatología", "prueba", "biopsia", "muestra", "forense", "genético", "medicina de laboratorio", "resultados", "análisis">
+			misuse = <"No debe utilizarse para registrar una autopsia o un informe forense, aunque las pruebas de algunas muestras que se toman en tales situaciones pueden representarse utilizando este arquetipo. En estos casos, se necesitarán arquetipos adicionales o especializados para representar los datos.
+
+Este arquetipo es adecuado para la representación de resultados generales de pruebas de laboratorio, pero no pretende abarcar informes sinópticos completos. En estos casos, se necesitarán arquetipos especializados adicionales para representar los datos.">
+		>
+		["ca"] = <
+			language = <[ISO_639-1::ca]>
+			purpose = <"Registrar el resultat, incloses les conclusions i la interpretació del laboratori, d'una investigació realitzada amb mostres recollides o relacionades amb un individu.">
+			use = <"S'utilitza per registrar el resultat, incloses les troballes i la interpretació del laboratori, d'una investigació realitzada en mostres recol·lectades d'un individu o relacionades amb aquest individu. Això normalment es fa en un laboratori, però es pot fer en altres entorns, com ara el lloc d'atenció.
+
+Aquest arquetip pretén cobrir el resultat d'una única investigació ordenada on les mostres es recullen com un únic procediment i pot incloure múltiples resultats d'analits o altres components. Exemples d'això podrien incloure un \"compte sanguini complet\", que donaria un resultat d'anàlit separat per al recompte de cada tipus de cèl·lula sanguínia, o una \"biòpsia renal no neoplàsica\", que donaria resultats mitjançant microscòpia, immunohistoquímica i microscòpia electrònica.
+
+Aquest arquetip ha estat dissenyat per ser un esborrany que generalment s'anirà ampliant amb arquetips CLUSTER per permetre el registre apropiat de patrons de resultats de proves de laboratori específics. Això inclou, entre d'altres, proves de bioquímica, hematologia, immunologia i serveis de transfusió, etc. i patrons específics per als requisits únics de microbiologia i anatomia patològica. Si les proves o les investigacions sol·licitades no estan englobades en cap grup, cada resultat de la prova normalment es representaria utilitzant instàncies separades d'aquest arquetip. No obstant això, hi ha una variació considerable a la pràctica real d'informes/missatgeria i aquest arquetip/arquetips relacionats estan dissenyats per manejar aquesta variació.
+
+Aquest arquetip admet múltiples enfocaments per al registre de mostres, cosa que reflecteix la pràctica actual que varia enormement. El resultat d‟una prova de laboratori té un alt grau d‟alineació amb un recurs d‟Informe de diagnòstic HL7 FHIR.
+
+Es preveu que una o més instàncies d'aquest arquetip o família d'arquetips s'enviaran de tornada al metge sol·licitant dins d'un document d'informe de laboratori que comprengui l'arquetip COMPOSITION.report_result, o similar, i altres arquetips ENTRY rellevants.
+
+El registre de factors de confusió pot ser inconsistent, depenent sovint del laboratori analitzador i de la informació clínica enviada pel sol·licitant. A la secció Estat de l'arquetip hi ha un element de dades simple de 'Factors de confusió', que és opcional i es pot repetir com una forma de registrar una varietat de factors simples que s'han de fer explícits, ja que poden influir en la interpretació dels resultats . Si els factors de confusió són més complexos, pot ser apropiat crear un arquetip de tipus CLUSTER local/compartit, que es pugui niar al SLOT 'Detalls dels factors de confusió'.
+Nota 1: Les condicions prèvies conegudes o requerides, com \"dejuni\" o \"Dia 1 del cicle menstrual\", s'han d'informar a l'element de dades \"Condicions de mostreig\" a l'arquetip CLUSTER.specimen, niat dins d'aquest arquetip OBSERVATION.
+Nota 2: Els problemes coneguts amb la recol·lecció o manipulació de mostres, com ara \"mostra hemolitzada\" o \"ús prolongat de torniquet\", s'han d'informar a \"Qualitat de la mostra\" a l'arquetip CLUSTER.specimen, niat dins d'aquest arquetip OBSERVATION.
+
+Quan el laboratori realitza \"proves de reflexos\", aquestes es poden manejar segons la guia US/FHIR (consulteu https://www.hl7.org/fhir/2015may/uslabreport-guide.html) o una altra política local. Per exemple, un dels següents...
+1. Registreu els resultats de la prova reflex addicional 'Resultats de la prova' dins del mateix 'openEHR-EHR-OBSERVATION.laboratory_test_result'
+2. Registreu els resultats de la prova reflex, com ara 'Resultats de la prova', dins d'un nou 'openEHR-EHR-OBSERVATION.laboratory_test_result' però consulteu la sol·licitud de prova de laboratori original a través de 'Detalls de la sol·licitud de prova'.
+3. Registreu els resultats de la prova reflex, com ara 'Resultats de la prova' dins d'un nou 'openEHR-EHR-OBSERVATION.laboratory_test_result' però feu referència a una nova sol·licitud de prova de laboratori, així com a la sol·licitud de prova de laboratori original a través de 'Detalls de la sol·licitud de prova'.">
+			keywords = <"laboratori", "patologia", "bioquímica", "hematologia", "microbiologia", "immunologia", "anatòmic", "químic", "clínic", "immunopatologia", "citologia", "histopatologia", "prova", "biòpsia", "mostra", "forense", "genètic", "medicina de laboratori", "resultats", "anàlisi">
+			misuse = <"No s'ha d'utilitzar per registrar una autòpsia o informe forense, encara que les proves d'algunes mostres que es prenen en aquestes situacions es poden representar utilitzant aquest arquetip. En aquests casos, caldrà arquetips addicionals o especialitzats per representar les dades.
+
+Aquest arquetip és adequat per a la representació de resultats generals de proves de laboratori, però no pretén abastar informes sinòptics complets. En aquests casos, caldrà arquetips especialitzats addicionals per representar les dades.">
+		>
+	>
+	lifecycle_state = <"published">
+	other_contributors = <"Andreas Abildgaard, OUS, Norway", "Yaser Abuhajjaj, United Arab Emirates", "Marit Alice Venheim, Helse Vest IKT, Norway", "Tomas Alme, DIPS ASA, Norway", "Vebjørn Arntzen, Oslo University Hospital, Norway (openEHR Editor)", "Koray Atalag, University of Auckland, New Zealand", "Silje Ljosland Bakke, Nasjonal IKT HF, Norway (openEHR Editor)", "Ryan Julius Banez, AC Health, Philippines", "Marcos Barreto, Universidade Federal da Bahia, Brazil", "Kristian Berg, Vestvågøy kommune - Fagutviklingsavdelingen, Norway", "SB Bhattacharyya, Sudisa Consultancy Services, India", "Sharmila Biswas, Dr Sharmila Biswas GP, Australia", "Johan Bjerner, Fürst, Norway", "Greg Burch, Tiny Medical Apps, United Kingdom", "Fatemeh Chalabianloo, Helse Bergen, Norway", "Doug Chesher, PaLMS, Australia", "Bjørn Christensen, Helse Bergen HF, Norway", "Stephen Chu, NEHTA, Australia (Editor)", "Matthew Cordell, NEHTA, Australia", "Lisbeth Dahlhaug, Helse Midt - Norge IT, Norway", "Andre de Wolf, NeHTA, Australia", "Gail Easterbrook, Flinders Medical Centre, Australia", "Stig Erik Hegrestad, Helse Førde, Norway", "David Evans, Queensland Health, Australia", "David Fallas, Sysmex NZ Ltd, New Zealand", "Shahla Foozonkhah, Iran ministry of health and education, Iran", "Hildegard Franke, freshEHR Clinical Informatics Ltd., United Kingdom", "Heath Frankel, Ocean Informatics, Australia", "Frode Gilberg, PRIDOK AS, Norway", "Rosane Gotardo, Systema Ltda., Brazil", "Heather Grain, Llewelyn Grain Informatics, Australia", "Grahame Grieve, Health Intersections Pyty Ltd, Australia (Editor)", "Åshild Halvorsen, Helse Nord RHF, Norway", "martin hanlon, Careworks, United Kingdom", "Sam Heard, Ocean Informatics, Australia", "Anca Heyd, DIPS ASA, Norway", "Geir Hoff, Sykehuset Telemark HF, Norway", "Evelyn Hovenga, EJSH Consulting, Australia", "Silje Kaada, Helse-Bergen, Avdeling for immunologi og transfusjonsmedisin, Norway", "Lars Morgan Karlsen, DIPS ASA, Norway", "Mary Kelaher, NEHTA, Australia", "Nils Kolstrup, Skansen Legekontor og Nasjonalt Senter for samhandling og telemedisin, Norway", "Anne Kristin Strand, Sykehuspartner HF, Norway", "Tomi Laptoš, Marand, Slovenia", "Liv Laugen, Oslo universitetssykehus, Norway", "Michael Legg, Michael Legg & associates, Australia", "Sabine Leh, Haukeland University Hospital, Department of Pathology, Norway", "Heather Leslie, Atomica Informatics, Australia (openEHR Editor)", "Neranga Liyanaarachchi, Ministry of Health, Postgraduate Institute of Medicine, Sri Lanka", "Zijian Li, China", "Jan-Arne Ludvigsen, DIPS AS, Norway", "Hallvard Lærum, Direktoratet for e-helse, Norway", "Manisha Mantri, C-DAC, India", "Siv Marie Lien, DIPS ASA, Norway", "Ole Martin Sand, DIPS ASA, Norway", "Mike Martyn, The Hobart Anaesthetic Group, Australia", "James McClay, University of Nebraska Medical Center, United States", "Andrew McIntyre, Medical-Objects, Australia", "David McKillop, NEHTA, Australia", "Hildegard McNicoll, freshEHR Clinical Informatics Ltd., United Kingdom", "Ian McNicoll, freshEHR Clinical Informatics, United Kingdom (openEHR Editor)", "Angela Merzweiler, University Hospital of Heidelberg, Germany", "Paul Miller, SCIMP NHS Scotland, United Kingdom", "Chris Mitchell, RACGP, Australia", "Stewart Morrison, NEHTA, Australia", "George Nikolaidis, Ergobyte Informatics S.A., Greece", "Bjørn Næss, DIPS AS, Norway", "Bjørn Odvar Eriksen, UNN, Norway", "Masafumi Okada, University of Tokyo, Japan", "Andrej Orel, Marand d.o.o., Slovenia", "Michael Osborne, Mater Health Services, Australia", "Vaclav Papez, University of West Bohemia, Czech Republic", "Anne Pauline Anderssen, Helse Nord RHF, Norway", "Ana Pereira, CINTESIS, CUF-Porto, Portugal", "Vladimir Pizzo, Hospital Sírio Libanês, Brazil", "Navin Ramachandran, NHS, United Kingdom", "Lars Retterstøl, OUS, Norway", "Jussara Rotzsch, Hospital Alemão Oswaldo Cruz, Brazil", "David Rowed, VAMC Clinic, Australia (Editor)", "Marcus vinicius de Régis, NUTES, Brazil", "Mona Saleh (Translator)", "Diogo Schmidt, UNISINOS, Brazil", "Gro-Hilde Severinsen, Norwegian center for ehealthresearch, Norway", "Anoop Shah, University College London, United Kingdom", "Kyle Shore, Charm Health, Australia", "Hildegunn Siv Aase, Helse Bergen, Norway", "Niclas Skyttberg, Karolinska Institutet, Sweden", "Matt Stibbs, Digi-M Ltd., United Kingdom", "Iztok Stotl, UKCLJ, Slovenia", "Norwegian Review Summary, Nasjonal IKT HF, Norway", "Line Sæle, Nasjonal IKT HF, Norway", "Sveinung Sørbye, UNN HF, Norway", "Nyree Taylor, Ocean Informatics, Australia", "Tesfay Teame, Folkehelseinstittutet, Norway", "Rowan Thomas, St. Vincent's Hospital Melbourne, Australia", "Michael Thompson, Queensland Health, Australia", "Gordon Tomes, Australian Institute of Health and Welfare, Australia", "Richard Townley-O'Neill, NEHTA, Australia", "Katrin Troeltzsch, Nationales Centrum für Tumorerkrankungen (NCT); Universitätsklinikum Heidelberg, Germany", "Torleif Trydal, Fürst AS, Norway", "Gro-Hilde Ulriksen, Norwegian center for ehealthresearch, Norway", "John Tore Valand, Helse Bergen, Norway (openEHR Editor)", "Wouter Zanen, Eurotranplant, Netherlands", "Lin Zhang, Taikang Insurance Group, China">
+	other_details = <
+		["licence"] = <"This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/.">
+		["custodian_organisation"] = <"openEHR Foundation">
+		["references"] = <"Based on Pathology Test Result, Draft Archetype [Internet]. Australian Digital Health Agency, Australian Digital Health Agency Clinical Knowledge Manager [cited: 2017-05-04]. Available from: http://dcm.nehta.org.au/ckm/#showArchetype_1013.1.839
+
+Pathology (Data Specifications) Version 1.0 [Internet]. Sydney, Australia: National E-Health Transition Authority; 2007 May 29 [cited 2011 Jul 11]; Available at http://www.nehta.gov.au/component/docman/doc_download/962-pathology-v10.
+
+Laboratory Technical Framework, Volume 3: Content, Revision 3.0 [Internet]. USA: IHE International; 2011 May 19; [cited 2011 Jul 11]. Available from: http://www.ihe.net/Technical_Framework/index.cfm#laboratory
+
+Hl7 FHIR Diagnostic Report resource: HL7 fhir; Available from http://www.hl7.org/implement/standards/fhir/diagnosticreport.html">
+		["original_namespace"] = <"org.openehr">
+		["original_publisher"] = <"openEHR Foundation">
+		["custodian_namespace"] = <"org.openehr">
+		["MD5-CAM-1.0.1"] = <"BBF73E0FED520D54F220CBFE141E0A5A">
+		["build_uid"] = <"846d3cd5-37e5-43a4-aabe-1989a08a0418">
+		["revision"] = <"1.2.7">
+	>
+
+definition
+	OBSERVATION[at0000] matches {    -- Laboratory test result
+		data matches {
+			HISTORY[at0001] matches {    -- Event Series
+				events cardinality matches {1..*; unordered} matches {
+					EVENT[at0002] occurrences matches {0..*} matches {    -- Any event
+						data matches {
+							ITEM_TREE[at0003] matches {    -- Tree
+								items cardinality matches {1..*; unordered} matches {
+									ELEMENT[at0005] matches {    -- Test name
+										value matches {
+											DV_TEXT matches {*}
+										}
+									}
+									allow_archetype CLUSTER[at0065] occurrences matches {0..*} matches {    -- Specimen detail
+										include
+											archetype_id/value matches {/openEHR-EHR-CLUSTER\.specimen(-[a-zA-Z0-9_]+)*\.v1/}
+									}
+									ELEMENT[at0073] occurrences matches {0..*} matches {    -- Overall test status
+										value matches {
+											DV_CODED_TEXT matches {
+												defining_code matches {
+													[local::
+													at0107,    -- Registered
+													at0037,    -- Partial
+													at0120,    -- Preliminary
+													at0038,    -- Final
+													at0040,    -- Amended
+													at0115,    -- Corrected
+													at0119,    -- Appended
+													at0074,    -- Cancelled
+													at0116]    -- Entered in error
+												}
+											}
+											DV_TEXT matches {*}
+										}
+									}
+									ELEMENT[at0075] occurrences matches {0..1} matches {    -- Overall test status timestamp
+										value matches {
+											DV_DATE_TIME matches {*}
+										}
+									}
+									ELEMENT[at0077] occurrences matches {0..1} matches {    -- Diagnostic service category
+										value matches {
+											DV_TEXT matches {*}
+										}
+									}
+									ELEMENT[at0100] occurrences matches {0..1} matches {    -- Clinical information provided
+										value matches {
+											DV_TEXT matches {*}
+										}
+									}
+									allow_archetype CLUSTER[at0097] occurrences matches {0..*} matches {    -- Test result
+										include
+											archetype_id/value matches {/openEHR-EHR-CLUSTER\.laboratory_test_analyte(-[a-zA-Z0-9_]+)*\.v1|openEHR-EHR-CLUSTER\.laboratory_test_panel(-[a-zA-Z0-9_]+)*\.v0|openEHR-EHR-CLUSTER\.laboratory_test_panel(-[a-zA-Z0-9_]+)*\.v1/}
+									}
+									ELEMENT[at0057] occurrences matches {0..1} matches {    -- Conclusion
+										value matches {
+											DV_TEXT matches {*}
+										}
+									}
+									ELEMENT[at0098] occurrences matches {0..*} matches {    -- Test diagnosis
+										value matches {
+											DV_TEXT matches {*}
+										}
+									}
+									allow_archetype CLUSTER[at0122] occurrences matches {0..*} matches {    -- Structured test diagnosis
+										include
+											archetype_id/value matches {/.*/}
+									}
+									allow_archetype CLUSTER[at0118] occurrences matches {0..*} matches {    -- Multimedia representation
+										include
+											archetype_id/value matches {/openEHR-EHR-CLUSTER\.media_file(-[a-zA-Z0-9_]+)*\.v1/}
+									}
+									ELEMENT[at0101] occurrences matches {0..*} matches {    -- Comment
+										value matches {
+											DV_TEXT matches {*}
+										}
+									}
+								}
+							}
+						}
+						state matches {
+							ITEM_TREE[at0112] matches {    -- Tree
+								items cardinality matches {0..*; unordered} matches {
+									ELEMENT[at0113] occurrences matches {0..*} matches {    -- Confounding factors
+										value matches {
+											DV_TEXT matches {*}
+										}
+									}
+									allow_archetype CLUSTER[at0114] occurrences matches {0..*} matches {    -- Structured confounding factors
+										include
+											archetype_id/value matches {/.*/}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		protocol matches {
+			ITEM_TREE[at0004] matches {    -- Tree
+				items cardinality matches {0..*; unordered} matches {
+					allow_archetype CLUSTER[at0017] occurrences matches {0..*} matches {    -- Receiving laboratory
+						include
+							archetype_id/value matches {/openEHR-EHR-CLUSTER\.organisation(-[a-zA-Z0-9_]+)*\.v1/}
+					}
+					ELEMENT[at0068] occurrences matches {0..1} matches {    -- Laboratory internal identifier
+						value matches {
+							DV_IDENTIFIER matches {*}
+							DV_TEXT matches {*}
+						}
+					}
+					CLUSTER[at0094] occurrences matches {0..*} matches {    -- Test request details
+						items cardinality matches {1..*; unordered} matches {
+							ELEMENT[at0106] occurrences matches {0..*} matches {    -- Original test requested name
+								value matches {
+									DV_TEXT matches {*}
+								}
+							}
+							ELEMENT[at0062] occurrences matches {0..1} matches {    -- Requester order identifier
+								value matches {
+									DV_IDENTIFIER matches {*}
+									DV_TEXT matches {*}
+								}
+							}
+							ELEMENT[at0063] occurrences matches {0..1} matches {    -- Receiver order identifier
+								value matches {
+									DV_IDENTIFIER matches {*}
+									DV_TEXT matches {*}
+								}
+							}
+							allow_archetype CLUSTER[at0090] occurrences matches {0..1} matches {    -- Requester
+								include
+									archetype_id/value matches {/openEHR-EHR-CLUSTER\.person(-[a-zA-Z0-9_]+)*\.v1/}
+							}
+							allow_archetype CLUSTER[at0035] occurrences matches {0..*} matches {    -- Distribution list
+								include
+									archetype_id/value matches {/openEHR-EHR-CLUSTER\.distribution(-[a-zA-Z0-9_]+)*\.v1/}
+							}
+						}
+					}
+					ELEMENT[at0111] occurrences matches {0..1} matches {    -- Point-of-care test
+						value matches {
+							DV_BOOLEAN matches {*}
+						}
+					}
+					ELEMENT[at0121] occurrences matches {0..1} matches {*}    -- Test method
+					allow_archetype CLUSTER[at0110] occurrences matches {0..*} matches {    -- Testing details
+						include
+							archetype_id/value matches {/openEHR-EHR-CLUSTER\.device(-[a-zA-Z0-9_]+)*\.v1/}
+					}
+					allow_archetype CLUSTER[at0117] occurrences matches {0..*} matches {    -- Extension
+						include
+							archetype_id/value matches {/.*/}
+					}
+				}
+			}
+		}
+	}
+
+
+ontology
+	term_definitions = <
+		["ar-sy"] = <
+			items = <
+				["at0000"] = <
+					text = <"*Laboratory test result(en)">
+					description = <"*The result, including findings and interpretation, of a laboratory investigation performed on specimens from individuals or related materials(en)">
+				>
+				["at0001"] = <
+					text = <"*Event Series(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0002"] = <
+					text = <"إحدى الوقائع">
+					description = <"إحدى الوقائع">
+				>
+				["at0003"] = <
+					text = <"*Tree(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0004"] = <
+					text = <"*Tree(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0005"] = <
+					text = <"*Test name(en)">
+					description = <"*Name of the laboratory investigation performed on the specimen(s). (en)">
+					comment = <"*A test result may be for a single analyte, or a group of items, including panel tests. It is strongly recommended that 'Test name' be coded with a terminology, for example LOINC or SNOMED CT. For example: 'Glucose', 'Urea and Electrolytes', 'Swab', 'Cortisol (am)', 'Potassium in perspiration' or 'Melanoma histopathology'. The name may sometimes include specimen type and patient state, for example 'Fasting blood glucose' or include other information, as 'Potassium (PNA blood gas)'. (en)">
+				>
+				["at0017"] = <
+					text = <"*Receiving laboratory(en)">
+					description = <"*Details of the laboratory which received the request and has overall responsibility to manage reporting of the test, even if other labs perform specific aspects.(en)">
+					comment = <"*This slot is intended to carry details of the laboratory which received the request and has overall responsibility to manage reporting of the test, even if other labs perform specific aspects.
+
+The receiving laboratory may either perform the test or refer it to another laboratory. Where a different laboratory is responsible for performing the testing on specific analytes, it would be expected that these details would be carried in the 'Analyte result detail' SLOT within the CLUSTER.laboratory_test_analyte archetype.
+
+ (en)">
+				>
+				["at0035"] = <
+					text = <"*Distribution list(en)">
+					description = <"*Details of additional clinicians or organisations who require a copy of the test result.(en)">
+					comment = <"*The 'Distribution list' is for information-only, and that the primary recipient of the report is the person intended to act on the information.(en)">
+				>
+				["at0037"] = <
+					text = <"*Partial(en)">
+					description = <"*This is a partial (e.g. initial, interim or preliminary) Test Result: data in the Test Result may be incomplete or unverified.(en)">
+				>
+				["at0038"] = <
+					text = <"*Final(en)">
+					description = <"*The Test result is complete and verified by an authorised person.(en)">
+				>
+				["at0040"] = <
+					text = <"*Amended(en)">
+					description = <"*The result has been modified subsequent to being Final, and is complete and verified by the responsible pathologist, and result data has been changed.(en)">
+				>
+				["at0057"] = <
+					text = <"*Conclusion(en)">
+					description = <"*Narrative description of the key findings. (en)">
+					comment = <"*For example: 'Pattern suggests significant renal impairment'. The content of the conclusion will vary, depending on the investigation performed. This conclusion should be aligned with the coded 'Test diagnosis'. (en)">
+					fhir_mapping = <"*DiagnosticReport.conclusion(en)">
+				>
+				["at0062"] = <
+					text = <"*Requester Order Identifier(en)">
+					description = <"*The local ID assigned to the test order by the order requester.(en)">
+					comment = <"*Equivalent to the HL7 Placer Order Identifier.(en)">
+				>
+				["at0063"] = <
+					text = <"*Receiver Order Identifier(en)">
+					description = <"*The local ID assigned to the test order by the order filler, usually by the Laboratory Information System (LIS).(en)">
+					comment = <"*Assigning an identifier to a request by the Laboratory lnformation System (LIS) enables tracking progress of the request and enables linking results to requests. It also provides a reference to assist with enquiries and it is usually equivalent to the HL7 Filler Order Identifier.(en)">
+				>
+				["at0065"] = <
+					text = <"*Specimen detail(en)">
+					description = <"*Details about the physical substance that has been analysed, in the situation where all results in this test are derived from the same specimen.(en)">
+					comment = <"*If the specimen type is sufficiently specified with a code in the Test name, then this additional data is not required. If there are multiple specimens, these may be represented per 'Result group'.(en)">
+				>
+				["at0068"] = <
+					text = <"*Laboratory internal identifier(en)">
+					description = <"*A local identifier assigned by the receiving Laboratory Information System (LIS) to track the test process. (en)">
+					comment = <"*This identifier is an internal tracking number assigned by the LIS, and it not intended to be the name of the test. (en)">
+				>
+				["at0073"] = <
+					text = <"*Overall test status(en)">
+					description = <"*The status of the laboratory test result as a whole.(en)">
+					comment = <"*The values have been specifically chosen to match those in the HL7 FHIR Diagnostic report, historically derived from HL7v2 practice. Other local codes/terms can be used via the Text 'choice'.
+
+This element is multiple occurrence to cater for the use cases where statuses for different aspects of the result have been split into several elements. (en)">
+				>
+				["at0074"] = <
+					text = <"*Cancelled(en)">
+					description = <"*The result is unavailable because the test was not started or not completed (also sometimes called 'aborted').(en)">
+				>
+				["at0075"] = <
+					text = <"*Overall test status timestamp(en)">
+					description = <"*The date and/or time that ‘Overall test status’ was issued.(en)">
+				>
+				["at0077"] = <
+					text = <"*Diagnostic service category(en)">
+					description = <"*The diagnostic service or discipline that is responsible for the laboratory test result. (en)">
+					comment = <"*This is intended to be a general categorisation and not to capture the organisational name of the laboratory. For example: anatomical pathology, immunology and transfusion medicine, medical microbiology, clinical pharmacology, medical genetics, medical biochemistry. Alternatively more granular sub categories or sub disciplines, such as endocrinology, haematology, and allergology services, may be used. This may assist clinicians in filtering between categories of results. Coding with a terminology is desirable, where possible.  (en)">
+				>
+				["at0090"] = <
+					text = <"*Requester(en)">
+					description = <"*Details of the clinician or organisation requesting the laboratory test result.(en)">
+				>
+				["at0094"] = <
+					text = <"*Test request details(en)">
+					description = <"*Details about the test request.(en)">
+					comment = <"*In most situations there is one test request and a single corresponding test result, however this repeating cluster allows for the situation where there may be multiple test requests reported using a single test result. As an example: 'a clinician asks for blood glucose in one request and Urea/electrolytes in a second request, but the lab analyser does both and the lab wishes to report these together'.(en)">
+				>
+				["at0097"] = <
+					text = <"*Test result (en)">
+					description = <"*Results of the test performed on the specimen(s). (en)">
+					comment = <"*This SLOT may carry an individual analyte, a group, panel or battery of multiple analytes, or a more complex and specific structure. (en)">
+				>
+				["at0098"] = <
+					text = <"*Test diagnosis(en)">
+					description = <"*Single word, phrase or brief description that represents the clinical meaning and significance of the laboratory test result. (en)">
+					comment = <"*For example: 'Severe hepatic impairment', 'Salmonella contamination'. Coding of the diagnosis with a terminology is strongly recommended, where possible. This diagnosis should be aligned with the narrative in the 'Conclusion'. (en)">
+				>
+				["at0100"] = <
+					text = <"*Clinical information provided(en)">
+					description = <"*Description of clinical information available at the time of interpretation of results.(en)">
+					comment = <"*This data element may include a link to the original clinical information provided in the test request.(en)">
+					fhir_mapping = <"*DiagnosticReport.requestDetail.clinicalNotes(en)">
+				>
+				["at0101"] = <
+					text = <"*Comment(en)">
+					description = <"*Additional narrative about the test result not captured in other fields.(en)">
+				>
+				["at0106"] = <
+					text = <"*Original test requested name(en)">
+					description = <"*Name of the original laboratory test requested. (en)">
+					comment = <"*This data element is to be used when the test requested differs from the test actually performed by the laboratory. (en)">
+				>
+				["at0107"] = <
+					text = <"*Registered(en)">
+					description = <"*The existence of the test is registered in the Laboratory Information System, but there is nothing yet available.(en)">
+				>
+				["at0110"] = <
+					text = <"*Testing details (en)">
+					description = <"*Structured details about the method of analysis, device or interpretation used.(en)">
+					comment = <"*For example: 'details of ELISA/nephelometry'.(en)">
+				>
+				["at0111"] = <
+					text = <"*Point-of-care test(en)">
+					description = <"*This indicates whether the test was performed directly at Point-of-Care (POCT) as opposed to a formal result from a laboratory or other service delivery organisation.(en)">
+					comment = <"*True if the test was performed directly at Point-of-Care (POCT).(en)">
+				>
+				["at0112"] = <
+					text = <"*Tree(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0113"] = <
+					text = <"*Confounding factors(en)">
+					description = <"*Issues or circumstances that impact on the accurate interpretation of the measurement or test result.(en)">
+					comment = <"*'Confounding factors' should be reserved for uncontrolled/unplanned issues of patient state/physiology that might affect interpretation, for example 'recent exercise' or 'recent tobacco smoking'.
+
+Known or required preconditions, such as 'fasting' should be carried in the 'Sampling conditions' element within the CLUSTER.specimen archetype . In some cases preconditions are captured as part of the test name, for example 'Fasting blood glucose'.
+
+Known issues with specimen collection or handling, such as 'prolonged use of tourniquet' or 'sample haemolysed', should be carried in the 'Specimen quality' elements within CLUSTER.specimen archetype.
+
+Coding with a terminology is desirable, where possible.  (en)">
+				>
+				["at0114"] = <
+					text = <"*Structured confounding factors (en)">
+					description = <"*Details of patient state that may alter interpretation of the laboratory test.(en)">
+					comment = <"*For example: Last Normal Menstrual Period (LNMP). (en)">
+				>
+				["at0115"] = <
+					text = <"*Corrected(en)">
+					description = <"*The result has been modified subsequent to being Final, and is complete and verified by the responsible pathologist. This is a sub-category of 'Amended'.(en)">
+				>
+				["at0116"] = <
+					text = <"*Entered in error(en)">
+					description = <"*The Test Result has been withdrawn following previous Final release.(en)">
+				>
+				["at0117"] = <
+					text = <"*Extension(en)">
+					description = <"*Slot to allow extension to support localisation or alignment with other standards/ reference models.(en)">
+				>
+				["at0118"] = <
+					text = <"*Multimedia representation(en)">
+					description = <"*Digital image, video or diagram representing the test result.(en)">
+					comment = <"*Multiple formats are allowed but they should represent equivalent clinical content.(en)">
+					fhir_mapping = <"*DiagnosticReport.presentedForm(en)">
+				>
+				["at0119"] = <
+					text = <"*Appended(en)">
+					description = <"*Subsequent to being final, the report has been modified by adding new content. The existing content is unchanged. This is a sub-category of 'Amended'.(en)">
+				>
+				["at0120"] = <
+					text = <"*Preliminary(en)">
+					description = <"*Verified early results are available, but not all results are final. This is a sub-category of 'Partial'.(en)">
+				>
+				["at0121"] = <
+					text = <"*Test method (en)">
+					description = <"*">
+					comment = <"*Coding with a terminology is desirable, where possible.  (en)">
+				>
+				["at0122"] = <
+					text = <"*Structured test diagnosis (en)">
+					description = <"*A structured or complex diagnosis for the laboratory test. (en)">
+					comment = <"*For example: Anatomical pathology diagnoses consisting of several different axes such as morphology, etiology and function. (en)">
+				>
+			>
+		>
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Laboratory test result">
+					description = <"The result, including findings and the laboratory's interpretation, of an investigation performed on specimens collected from an individual or related to that individual.">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Any event">
+					description = <"Default, unspecified point in time or interval event which may be explicitly defined in a template or at run-time.">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0005"] = <
+					text = <"Test name">
+					description = <"Name of the laboratory investigation performed on the specimen(s).">
+					comment = <"A test result may be for a single analyte, or a group of items, including panel tests. It is strongly recommended that 'Test name' be coded with a terminology, for example LOINC or SNOMED CT. For example: 'Glucose', 'Urea and Electrolytes', 'Swab', 'Cortisol (am)', 'Potassium in perspiration' or 'Melanoma histopathology'. The name may sometimes include specimen type and patient state, for example 'Fasting blood glucose' or include other information, as 'Potassium (PNA blood gas)'.">
+				>
+				["at0017"] = <
+					text = <"Receiving laboratory">
+					description = <"Details of the laboratory which received the request and has overall responsibility to manage reporting of the test, even if other labs perform specific aspects.">
+					comment = <"This slot is intended to carry details of the laboratory which received the request and has overall responsibility to manage reporting of the test, even if other labs perform specific aspects.
+
+The receiving laboratory may either perform the test or refer it to another laboratory. Where a different laboratory is responsible for performing the testing on specific analytes, it would be expected that these details would be carried in the 'Analyte result detail' SLOT within the CLUSTER.laboratory_test_analyte archetype.
+
+">
+				>
+				["at0035"] = <
+					text = <"Distribution list">
+					description = <"Details of additional clinicians or organisations who require a copy of the test result.">
+					comment = <"The 'Distribution list' is for information-only, and that the primary recipient of the report is the person intended to act on the information.">
+				>
+				["at0037"] = <
+					text = <"Partial">
+					description = <"This is a partial (e.g. initial, interim or preliminary) Test Result: data in the Test Result may be incomplete or unverified.">
+				>
+				["at0038"] = <
+					text = <"Final">
+					description = <"The Test result is complete and verified by an authorised person.">
+				>
+				["at0040"] = <
+					text = <"Amended">
+					description = <"The result has been modified subsequent to being Final, and is complete and verified by the responsible pathologist, and result data has been changed.">
+				>
+				["at0057"] = <
+					text = <"Conclusion">
+					description = <"Narrative description of the key findings.">
+					comment = <"For example: 'Pattern suggests significant renal impairment'. The content of the conclusion will vary, depending on the investigation performed. This conclusion should be aligned with the coded 'Test diagnosis'.">
+				>
+				["at0062"] = <
+					text = <"Requester order identifier">
+					description = <"The local identifier assigned by the requesting clinical system.">
+					comment = <"Equivalent to the HL7 Placer Order Identifier.">
+				>
+				["at0063"] = <
+					text = <"Receiver order identifier">
+					description = <"The local identifier assigned to the test order by the order filler, usually by the Laboratory Information System (LIS).">
+					comment = <"Assigning an identifier to a request by the Laboratory lnformation System (LIS) enables tracking progress of the request and enables linking results to requests. It also provides a reference to assist with enquiries and it is usually equivalent to the HL7 Filler Order Identifier.">
+				>
+				["at0065"] = <
+					text = <"Specimen detail">
+					description = <"Details about the physical substance that has been analysed.">
+					comment = <"If the specimen type is sufficiently specified with a code in the Test name, then this additional data is not required. Linking results to specific specimens may be recorded using 'Specimen identifier' elements in both the CLUSTER.specimen and the various results CLUSTER archetypes.">
+				>
+				["at0068"] = <
+					text = <"Laboratory internal identifier">
+					description = <"A local identifier assigned by the receiving Laboratory Information System (LIS) to track the test process.">
+					comment = <"This identifier is an internal tracking number assigned by the LIS, and it not intended to be the name of the test.">
+				>
+				["at0073"] = <
+					text = <"Overall test status">
+					description = <"The status of the laboratory test result as a whole.">
+					comment = <"The values have been specifically chosen to match those in the HL7 FHIR Diagnostic report, historically derived from HL7v2 practice. Other local codes/terms can be used via the Text 'choice'.
+
+This element is multiple occurrence to cater for the use cases where statuses for different aspects of the result have been split into several elements.">
+				>
+				["at0074"] = <
+					text = <"Cancelled">
+					description = <"The result is unavailable because the test was not started or not completed (also sometimes called 'aborted').">
+				>
+				["at0075"] = <
+					text = <"Overall test status timestamp">
+					description = <"The date and/or time that ‘Overall test status’ was issued.">
+				>
+				["at0077"] = <
+					text = <"Diagnostic service category">
+					description = <"The diagnostic service or discipline that is responsible for the laboratory test result.">
+					comment = <"This is intended to be a general categorisation and not to capture the organisational name of the laboratory. For example: anatomical pathology, immunology and transfusion medicine, medical microbiology, clinical pharmacology, medical genetics, medical biochemistry. Alternatively more granular sub categories or sub disciplines, such as endocrinology, haematology, and allergology services, may be used. This may assist clinicians in filtering between categories of results. Coding with a terminology is desirable, where possible.">
+				>
+				["at0090"] = <
+					text = <"Requester">
+					description = <"Details of the clinician or organisation requesting the laboratory test result.">
+				>
+				["at0094"] = <
+					text = <"Test request details">
+					description = <"Details about the test request.">
+					comment = <"In most situations there is one test request and a single corresponding test result, however this repeating cluster allows for the situation where there may be multiple test requests reported using a single test result.
+
+As an example: 'a clinician asks for blood glucose in one request and Urea/electrolytes in a second request, but the lab analyser does both and the lab wishes to report these together'.">
+				>
+				["at0097"] = <
+					text = <"Test result">
+					description = <"Results of the test performed on the specimen(s).">
+					comment = <"This SLOT may carry an individual analyte, a group, panel or battery of multiple analytes, or a more complex and specific structure.">
+				>
+				["at0098"] = <
+					text = <"Test diagnosis">
+					description = <"Single word, phrase or brief description that represents the clinical meaning and significance of the laboratory test result.">
+					comment = <"For example: 'Severe hepatic impairment', 'Salmonella contamination'. Coding of the diagnosis with a terminology is strongly recommended, where possible. This diagnosis should be aligned with the narrative in the 'Conclusion'.">
+				>
+				["at0100"] = <
+					text = <"Clinical information provided">
+					description = <"Description of clinical information available at the time of interpretation of results.">
+					comment = <"This data element may include a link to the original clinical information provided in the test request.">
+				>
+				["at0101"] = <
+					text = <"Comment">
+					description = <"Additional narrative about the test result not captured in other fields.">
+				>
+				["at0106"] = <
+					text = <"Original test requested name">
+					description = <"Name of the original laboratory test requested.">
+					comment = <"This data element is to be used when the test requested differs from the test actually performed by the laboratory.">
+				>
+				["at0107"] = <
+					text = <"Registered">
+					description = <"The existence of the test is registered in the Laboratory Information System, but there is nothing yet available.">
+				>
+				["at0110"] = <
+					text = <"Testing details">
+					description = <"Structured details about the method of analysis, device or interpretation used.">
+					comment = <"For example: 'details of ELISA/nephelometry'.">
+				>
+				["at0111"] = <
+					text = <"Point-of-care test">
+					description = <"This indicates whether the test was performed directly at Point-of-Care (POCT) as opposed to a formal result from a laboratory or other service delivery organisation.">
+					comment = <"True if the test was performed directly at Point-of-Care (POCT).">
+				>
+				["at0112"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0113"] = <
+					text = <"Confounding factors">
+					description = <"Issues or circumstances that impact on the accurate interpretation of the measurement or test result.">
+					comment = <"'Confounding factors' should be reserved for uncontrolled/unplanned issues of patient state/physiology that might affect interpretation, for example 'recent exercise' or 'recent tobacco smoking'.
+
+Known or required preconditions, such as 'fasting' should be carried in the 'Sampling conditions' element within the CLUSTER.specimen archetype . In some cases preconditions are captured as part of the test name, for example 'Fasting blood glucose'.
+
+Known issues with specimen collection or handling, such as 'prolonged use of tourniquet' or 'sample haemolysed', should be carried in the 'Specimen quality' elements within CLUSTER.specimen archetype.
+
+Coding with a terminology is desirable, where possible.">
+				>
+				["at0114"] = <
+					text = <"Structured confounding factors">
+					description = <"Details of issues or circumstances that impact on the accurate interpretation of the measurement or test result.">
+					comment = <"For example: Last Normal Menstrual Period (LNMP).">
+				>
+				["at0115"] = <
+					text = <"Corrected">
+					description = <"The result has been modified subsequent to being Final, and is complete and verified by the responsible pathologist. This is a sub-category of 'Amended'.">
+				>
+				["at0116"] = <
+					text = <"Entered in error">
+					description = <"The Test Result has been withdrawn following previous Final release.">
+				>
+				["at0117"] = <
+					text = <"Extension">
+					description = <"Additional information required to capture local content or to align with other reference models/formalisms.">
+					comment = <"For example: local information requirements or additional metadata to align with FHIR or CIMI equivalents.">
+				>
+				["at0118"] = <
+					text = <"Multimedia representation">
+					description = <"Digital image, video or diagram representing the test result.">
+					comment = <"Multiple formats are allowed but they should represent equivalent clinical content.">
+				>
+				["at0119"] = <
+					text = <"Appended">
+					description = <"Subsequent to being final, the report has been modified by adding new content. The existing content is unchanged. This is a sub-category of 'Amended'.">
+				>
+				["at0120"] = <
+					text = <"Preliminary">
+					description = <"Verified early results are available, but not all results are final. This is a sub-category of 'Partial'.">
+				>
+				["at0121"] = <
+					text = <"Test method">
+					description = <"Description about the method used to perform the test.">
+					comment = <"Coding with a terminology is desirable, where possible.">
+				>
+				["at0122"] = <
+					text = <"Structured test diagnosis">
+					description = <"A structured or complex diagnosis for the laboratory test.">
+					comment = <"For example: Anatomical pathology diagnoses consisting of several different axes such as morphology, etiology and function.">
+				>
+			>
+		>
+		["nb"] = <
+			items = <
+				["at0000"] = <
+					text = <"Laboratorieresultat">
+					description = <"Resultat, inkludert funn og laboratoriets tolkning, av en laboratorieundersøkelse utført på prøvemateriale fra et individ eller relatert til individet.">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Uspesifisert hendelse">
+					description = <"Standard, uspesifisert tidspunkt eller tidsintervall som kan defineres mer eksplisitt i en templat eller i en applikasjon.">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0005"] = <
+					text = <"Undersøkelsesnavn">
+					description = <"Navn på laboratorieundersøkelsen som er utført på prøvematerialet.">
+					comment = <"Undersøkelsesnavnet kan dekke ett enkelt resultat eller en gruppe av resultater. Undersøkelsesnavnet kan kodes med medisinsk kodeverk som for eksempel NLK (Norsk laboratoriekodeverk), LOINC, SNOMED CT eller lokale laboratoriekodeverk. Eksempler kan være \"Glukose\", \"Elektrolytter\", \"Blodgass\", \"Differensialtelling\", \"Dyrkning\", \"Kortisol (morgen)\" eller \"histologi melanom\". Navnet kan noen ganger inneholde typen prøvemateriale og/eller pasientstatus, for eksempel \"fastende blodglukose\" \"Kalium i svette\", eller inneholde annen informasjon, som \"Kalium (PNA blodgass)\".">
+				>
+				["at0017"] = <
+					text = <"Ansvarlig laboratorium">
+					description = <"Detaljer om laboratoriet som mottok den opprinnelige rekvisisjonen og har det overordnede ansvaret for prøven, selv om det er andre laboratorier som utfører de enkelte analysene.">
+					comment = <"Dette SLOTet er ment for detaljer om laboratoriet som mottok rekvisisjonen og har det overordnede ansvaret for å sende en svarrapport, selv om andre laboratorier utfører spesifikke deler av den.
+
+Det ansvarlige laboratoriet kan enten utføre undersøkelsene selv, eller videresende til andre laboratorier. Hvis et annet laboratorium har utført spesifikke undersøkelser bør informasjon om dette bli beskrevet i SLOTet \"Detaljer om analyseresultat\" i arketypen \"Analyseresultat\".
+
+\"Ansvarlig laboratorium\" kalles ofte \"Tjenesteyter\".">
+				>
+				["at0035"] = <
+					text = <"Kopimottakere">
+					description = <"Detaljert informasjon knyttet til kliniker eller organisatorisk enhet som skal motta en kopi av laboratoriesvaret.">
+					comment = <"Personene eller organisasjonene på distribusjonslisten mottar svaret kun til informasjon, og det er hovedmottakeren av rapporten som forventes å agere på den.">
+				>
+				["at0037"] = <
+					text = <"Ufullstendig">
+					description = <"Dette er et delvis (dvs initalt, foreløpig eller preliminært) svar: Data i svaret kan være ukomplett eller ubekreftet.">
+				>
+				["at0038"] = <
+					text = <"Endelig">
+					description = <"Svaret er komplett og er bekreftet av ansvarlig person.">
+				>
+				["at0040"] = <
+					text = <"Revidert">
+					description = <"Svaret har blitt modifisert etter å ha vært i status \"Endelig\", og er komplett og verifisert av ansvarlig person, og svardata er endret.">
+				>
+				["at0057"] = <
+					text = <"Konklusjon">
+					description = <"Fritekstbeskrivelse av de viktigste funnene.">
+					comment = <"For eksempel \"mønsteret indikerer betydelig nedsatt nyrefunksjon\". Innholdet av konklusjonen vil variere, basert på hvilken undersøkelse som er utført. Konklusjonen bør være i overensstemmelse med kodene brukt i elementet \"Diagnose\".">
+				>
+				["at0062"] = <
+					text = <"Rekvirentens rekvisisjonsID">
+					description = <"Rekvirentens/bestillers lokale ID for rekvisisjonen.">
+					comment = <"Tilsvarende HL7 \"Placer Order Identifier\".">
+				>
+				["at0063"] = <
+					text = <"Rekvisisjonsmottakers rekvisisjonsID">
+					description = <"Bestillingens/rekvisisjonens lokale identifikator/referansenummer tildelt av tjenesteyter/mottaker, som regel av LIMS.">
+					comment = <"Når Laboratorieinformasjonssystemet (LIMS) tildeler en identifikator, åpnes det for sporing av fremdriften/prosessforløpet på bestillingen av undersøkelsen/rekvisisjonen og for å koble undersøkelsesresultatet til rekvisisjonen/bestillingen. Som regel tilsvarer dette HL7 \"Filler Order Identifier\".
+
+Denne identifikatoren kalles også ofte \"rekvisisjonsnummer\" eller \"remissenummer\".">
+				>
+				["at0065"] = <
+					text = <"Prøvedetaljer">
+					description = <"Detaljer om den fysiske substansen som er analysert.">
+					comment = <"Hvis prøvematerialet er tilstrekkelig spesifisert med en kode i analysenavnet er ikke dette dataelementet nødvendig. Det er mulig å koble svar med spesifikke prøver ved hjelp av elementene \"ID for prøvemateriale\" i både CLUSTER.specimen og de forskjellige CLUSTER-arketypene for laboratoriesvar.">
+				>
+				["at0068"] = <
+					text = <"Laboratorieintern identifikator">
+					description = <"En lokal identifikator tildelt av det mottagende laboratoriesystemet (LIMS), for å kunne spore analyseprosessen.">
+					comment = <"Denne identifikatoren er et internt sporingsnummer tildelt av LIMS, og det er ikke ment å være navnet på undersøkelsen.">
+				>
+				["at0073"] = <
+					text = <"Overordnet resultatstatus">
+					description = <"Den overordnede statusen for hele laboratorieresultatet/prøven.">
+					comment = <"Verdiene er valgt spesifikt for å samsvare med verdiene i HL7 FHIR-ressursen \"Diagnostic report\", som historisk sett kommer fra HL7 v2. Andre lokale koder eller termer kan brukes ved å bruke datatypen \"Fri eller kodet tekst.
+
+Dette elementet kan repeteres for å understøtte bruksområdene der statuser for forskjellige aspekter av resultatet er delt opp i flere elementer. Et eksempel på dette er de norske standard labsvarmeldingene i HIS 1.4-standarden, der status for svaret og status for laboratorieprosessen håndteres separat.">
+				>
+				["at0074"] = <
+					text = <"Kansellert">
+					description = <"Svaret er utilgjengelig fordi analysen ikke ble påbegynt eller ferdigstilt (også kalt \"avbrutt\").">
+				>
+				["at0075"] = <
+					text = <"Tidsangivelse for overordnet resultatstatus">
+					description = <"Tidspunktet for utstedelsen av \"Overordnet resultatstatus\".">
+				>
+				["at0077"] = <
+					text = <"Laboratoriedisiplin">
+					description = <"Laboratoriefagområdet, -disiplinen eller subdisiplinen som er ansvarlig for resultatet.">
+					comment = <"Dette er ikke ment for å gjenspeile laboratoriets interne organisering, men for å angi hvilken laboratoriedisiplin analysene tilhører. For eksempel patologi, immunologi og transfusjonsmedisin, medisinsk mikrobiologi, klinisk farmakologi, medisinsk genetikk og medisinsk biokjemi. Eventuelt enda mer findelte subkategorier eller subdisipliner som f.eks. hormoner/endokrinologi, hematologi, allergologi. Dette hjelper klinikere med å filtrere mellom resultatkategorier i henhold til lokalt oppsett. Koding med en terminologi er ønskelig, der det er mulig.">
+				>
+				["at0090"] = <
+					text = <"Rekvirent">
+					description = <"Detaljert informasjon knyttet til kliniker eller organisatorisk enhet som har rekvirert/bestilt analysen.">
+				>
+				["at0094"] = <
+					text = <"Rekvisisjonsdetaljer">
+					description = <"Detaljer knyttet til rekvisisjonen.">
+					comment = <"I de fleste situasjoner finnes det én rekvisisjon og ett korresponderende svar, men under noen omstendigheter kan flere rekvisisjoner representeres ved hjelp av en enkelt laboratorieresultat-arketype.
+
+For eksempel kan en kliniker bestille \"glukose\" i en rekvisisjon og \"urea og elektrolytter\" i en ytterligere rekvisisjon, mens laboratoriet utfører begge analysene og sender en samlet rapport.">
+				>
+				["at0097"] = <
+					text = <"Undersøkelsesresultat">
+					description = <"Resultat av undersøkelsen som er utført på prøvematerialet.">
+					comment = <"Dette SLOTet kan inneholde resultat for ett enkelt analyseresultat, for en gruppe analyseresultater, eller for en mer kompleks og spesifikk struktur.">
+				>
+				["at0098"] = <
+					text = <"Diagnose">
+					description = <"Enkeltord, frase eller kort beskrivelse som representerer den kliniske betydningen og signifikansen av laboratorieresultatet.">
+					comment = <"For eksempel \"Betydelig nedsatt leverfunksjon\" eller \"Salmonella\". Koding med en terminologi foretrekkes, der det er mulig. Diagnosen bør være i overensstemmelse med teksten i \"Konklusjon\".">
+				>
+				["at0100"] = <
+					text = <"Tilgjengelig klinisk informasjon">
+					description = <"Beskrivelse av klinisk informasjon som er tilgjengelig på tolkningstidspunktet.">
+					comment = <"Dette dataelementet kan inkludere en lenke til den opprinnelige kliniske informasjonen som ble angitt i rekvisisjonen.">
+				>
+				["at0101"] = <
+					text = <"Kommentar">
+					description = <"Tekstlig tilleggsinformasjon om analyseresultatet, som ikke er registrert i andre felt.">
+				>
+				["at0106"] = <
+					text = <"Navn på opprinnelig rekvirert analyse">
+					description = <"Navn på undersøkelsen som opprinnelig ble rekvirert.">
+					comment = <"Dette dataelementet er tenkt brukt dersom det er forskjell mellom undersøkelsen som er rekvirert og den som faktisk er utført.">
+				>
+				["at0107"] = <
+					text = <"Registrert">
+					description = <"Analysen er registrert i laboratoriesystemet, men svaret er ikke tilgjengelig per nå.">
+				>
+				["at0110"] = <
+					text = <"Undersøkelsesdetaljer">
+					description = <"Strukturert tilleggsinformasjon om hvilken analysemetode, utstyr eller tolkning som er benyttet.">
+					comment = <"For eksempel \"detaljer om ELISA/nefelometri\".">
+				>
+				["at0111"] = <
+					text = <"Pasientnær analysering">
+					description = <"Dette indikerer hvorvidt analysen ble utført gjennom pasientnær analysering (PNA) i stedet for en mer formell laboratorietjeneste.">
+					comment = <"Sann dersom analysen ble utført ved pasientnær analysering (PNA).">
+				>
+				["at0112"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0113"] = <
+					text = <"Konfunderende faktorer">
+					description = <"Forhold eller omstendigheter som påvirker tolkningen av laboratorieresultatet.">
+					comment = <"\"Konfunderende faktorer\" bør være reservert for ukontrollerte eller uplanlagte forhold hos pasienten som kan påvirke tolkningen av laboratorieresultatet. For eksempel \"nylig fysisk aktivitet\", \"nylig røykt tobakk\". 
+
+Kjente forutsetninger som \"fastende\" bør dokumenteres i elementet \"Prøvetakingsforhold\" i arketypen CLUSTER.specimen. I noen tilfeller er slike forutsetninger del av undersøkelsesnavnet, for eksempel \"Fastende blodsukker\".
+
+Kjente forhold knyttet til prøvetaking eller håndtering av prøven, som \"langvarig stase\" eller \"hemolyse\" (preanalytiske forhold) bør dokumenteres i elementet \"Prøvekvalitet\" i arketypen CLUSTER.specimen.
+
+Koding med en terminologi er ønskelig, der det er mulig.">
+				>
+				["at0114"] = <
+					text = <"Strukturerte konfunderende faktorer">
+					description = <"Ytterligere detaljer om forhold i tilstand eller omstendigheter som kan påvirke tolkningen av laboratorieresultatet.">
+					comment = <"For eksempel siste normale menstruasjonsperiode.">
+				>
+				["at0115"] = <
+					text = <"Korrigert">
+					description = <"Svaret har blitt modifisert etter å ha vært i status \"Endelig\" og er komplett og verifisert. Dette er en underkategori til \"Revidert\".">
+				>
+				["at0116"] = <
+					text = <"Feilregistrert">
+					description = <"Analysesvaret har blitt trukket tilbake etter å ha vært i status \"Endelig\".">
+				>
+				["at0117"] = <
+					text = <"Tilleggsinformasjon">
+					description = <"Ytterligere informasjon som trengs for å kunne registrere lokalt definert innhold eller for å tilpasse til andre referansemodeller/formalismer.">
+					comment = <"For eksempel lokale informasjonsbehov eller ytterligere metadata for å kunne tilpasse til tilsvarende konsepter i FHIR eller CIMI.">
+				>
+				["at0118"] = <
+					text = <"Multimediarepresentasjon">
+					description = <"Digitalt bilde, video eller diagram som representerer analyseresultatet.">
+					comment = <"Flere formater tillates, men innholdet i de forskjellige formatene må representere det samme innholdet.">
+				>
+				["at0119"] = <
+					text = <"Tillegg">
+					description = <"Etter å ha vært satt som status \"Endelig\", har det blitt lagt nytt innhold til rapporten. Det eksisterende innholdet er uendret. Dette er en underkategori av \"Revidert\".">
+				>
+				["at0120"] = <
+					text = <"Foreløpig">
+					description = <"Verifiserte tidlige svar er tilgjengelige, men ikke alle svar er endelige. Dette er en underkategori av \"Ufullstendig\".">
+				>
+				["at0121"] = <
+					text = <"Undersøkelsesmetode">
+					description = <"Beskrivelse av metoden som ble brukt for å utføre undersøkelsen.">
+					comment = <"Koding med en terminologi er ønskelig, der det er mulig.">
+				>
+				["at0122"] = <
+					text = <"Strukturert diagnose">
+					description = <"En strukturert eller kompleks diagnose for laboratorieundersøkelsen.">
+					comment = <"For eksempel patologidiagnoser bestående av flere forskjellige akser som morfologi, etiologi og funksjon.">
+				>
+			>
+		>
+		["zh-cn"] = <
+			items = <
+				["at0000"] = <
+					text = <"实验室检验结果">
+					description = <"旨在用于记录对于从个人身上所采集的标本或者与该个人相关的标本进行检验的结果，包括结果所见/发现和实验室的解释。">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"任何事件">
+					description = <"可以在模板之中或者在运行时加以明确定义的，默认的，未明示的时间点或时间区间事件。">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0005"] = <
+					text = <"检验项目名称">
+					description = <"针对标本所进行的实验室检验项目的名称。">
+					comment = <"检验结果可能代表的是单独一种分析物或者是一组项目/分析物，包括成套的检验项目（组套检验项目）。强烈建议采用特定的术语标准（如 LOINC 或 SNOMED CT）对“检验项目名称”加以编码。例如：“葡萄糖”、“尿素和电解质”、“拭子”、“皮质醇 （上午）”、“汗液钾离子”或“黑色素瘤组织病理学”。检验项目名称之中有时可能会包括标本类型和患者状态，如“空腹血糖”，或者是包括其他的信息，如“钾（PNA 血气）”。">
+				>
+				["at0017"] = <
+					text = <"接收方实验室">
+					description = <"关于当时接收了相应的检验申请并整体负责管理当前检验项目的报告工作的实验室的详情，即使其他实验室执行其中的特定方面。">
+					comment = <"此槽位旨在记录关于当时接收了相应的检验申请并整体负责管理当前检验项目的报告工作的实验室的详情，即使其他实验室执行其中的特定方面。
+
+接收方实验室可能会自身来执行当前的检验项目，或者也可能将其转交给其他的实验室。如果其他实验室负责检测特定的分析物，则应当期望这些详情包含在群簇型实验室检验项目分析物原始型（CLUSTER.laboratory_test_analyte）里的分析物结果详情槽位“Analyte result detail”之中。">
+				>
+				["at0035"] = <
+					text = <"分发列表">
+					description = <"其他那些要求获得当前实验室检验结果的临床医生或组织机构。">
+					comment = <"“分发列表”仅供参考，报告的首要接收方则是意在依据当前的实验室检验结果采取行动的人员。">
+				>
+				["at0037"] = <
+					text = <"部分">
+					description = <"当前还属于部分的（比如，初始的、暂时的或初步的）检验结果：检验结果之中的数据可能不完整或者未经核对。">
+				>
+				["at0038"] = <
+					text = <"最终">
+					description = <"检验结果完整且经过授权人员的核对或者说审核。">
+				>
+				["at0040"] = <
+					text = <"经过修正">
+					description = <"结果在达到最终状态之后已被修改，是完整的结果，经过了负责的病理学工作人员的核对，且已经更改了结果数据。">
+				>
+				["at0057"] = <
+					text = <"结论">
+					description = <"关于关键所见/发现的文字叙述型描述。">
+					comment = <"例如：“[所观察到的]模式表明存在显著的肾脏损害”。结论的内容会根据所进行的检查而有所不同。此项结论应当与编码型的检验项目诊断数据元“Test diagnosis”保持一致。">
+					fhir_mapping = <"*DiagnosticReport.conclusion(en)">
+				>
+				["at0062"] = <
+					text = <"申请方医嘱标识符">
+					description = <"申请方临床系统所赋予当前检验项目医嘱/申请的本地标识符。">
+					comment = <"等价于HL7申请方医嘱标识符（ Placer Order Identifier）。">
+				>
+				["at0063"] = <
+					text = <"接收方医嘱标识符">
+					description = <"医嘱执行方赋予当前检验项目医嘱/申请的本地标识符。其中，医嘱执行方通常为实验室信息系统（ Laboratory Information System，LIS）。">
+					comment = <"实验室信息系统（ Laboratory Information System，LIS）为检验项目医嘱/申请赋予标识符，将便于实现对于申请进展情况的跟踪以及结果与相应医嘱/申请的链接。同时，这也是有助于查询的一种参考信息（reference），且通常等价于HL7执行方医嘱标识符（Filler Order Identifier）。">
+				>
+				["at0065"] = <
+					text = <"标本详情">
+					description = <"关于所已经分析的物质的详情。">
+					comment = <"如果利用检验项目名称之中的代码可以充分明确相应的标本类型，则不需要此项附加的数据。可以采用群簇型标本原始型（CLUSTER.specimen）和各种的群簇型结果原始型之中的标本标识符元素“Specimen identifier”元素来记录关于将结果链接到特定标本的信息。">
+				>
+				["at0068"] = <
+					text = <"实验室内部标识符">
+					description = <"接收方实验室信息系统（Laboratory Information System，LIS）所分配的本地标识符，用于跟踪检验过程。">
+					comment = <"该标识符属于是实验室信息系统（Laboratory Information System，LIS）所分配的内部追踪编号，但并非旨在作为检验项目的名称。">
+				>
+				["at0073"] = <
+					text = <"检验项目总体状态">
+					description = <"当前的实验室检验项目作为整体的状态">
+					comment = <"这些编码型取值是经过专门挑选的，以与 HL7 FHIR 诊断报告资源之中的取值相匹配，而在历史上这些取值源自 HL7v2 实践。另外，可以借助于文本型选项“choice”来使用其他的本地代码/术语。
+
+本数据元可以多次出现，以适应那些将结果不同方面的状态拆分成多个数据元的用例。">
+				>
+				["at0074"] = <
+					text = <"已撤销">
+					description = <"当前结果不可用，因为该检验项目并未开始或者并未完成（有时又称为“取消”、“已中止”或“已放弃”）。">
+				>
+				["at0075"] = <
+					text = <"检验项目总体状态时间戳">
+					description = <"发布检验项目总体状态时的日期和/或时间。">
+				>
+				["at0077"] = <
+					text = <"诊断服务类别">
+					description = <"负责当前实验室检验结果的诊断服务或学科。">
+					comment = <"本数据元旨在进行一般的分类，而并非旨在记录实验室的组织结构名称。例如：解剖病理学、免疫学、输血医学、医学微生物学、临床药理学、医学遗传学、医学生物化学。或者，还可以采用粒度更精细的子类别或子学科，如内分泌学、血液学和变态反应学服务。此项数据可能有助于临床医生在结果类别之间进行筛选。最好尽可能采用特定的术语标准加以编码。">
+				>
+				["at0090"] = <
+					text = <"申请方">
+					description = <"关于申请当前实验室检验项目（结果）的临床医生或组织机构的详情。">
+				>
+				["at0094"] = <
+					text = <"检验申请详情">
+					description = <"关于检验申请的详情。">
+					comment = <"在大多数情况下，每份检验请求分别会有相应的单独一项检验结果。不过，这个可重复的群簇允许存在检验结果只有一份[报告]而报告所针对的却是多份检验请求的情况。
+
+例如：医生在一份申请当中要求检测血糖，而在另一份申请中则要求检测尿素/电解质，而实验室分的析仪则会同时处理这两份申请，并且实验室希望将二者一并加以报告。">
+				>
+				["at0097"] = <
+					text = <"检验结果">
+					description = <"针对标本所进行的检验项目的结果。">
+					comment = <"此槽位之中可以包含的是单个的分析物、多个分析物所构成的组合或组套，或者是更为复杂的特定结构。">
+				>
+				["at0098"] = <
+					text = <"检验项目诊断">
+					description = <"代表实验室测试结果的临床含义和意义/重要性的单词、短语或简短描述。">
+					comment = <"例如：“严重肝脏损害”、“沙门菌污染”。强烈建议尽可能采用特定的术语标准对此项诊断加以编码。此项诊断应当与结论数据元“Conclusion”之中的文字叙述保持一致。">
+				>
+				["at0100"] = <
+					text = <"已提供的临床信息">
+					description = <"关于解释结果时可用的临床信息的描述。">
+					comment = <"本数据元之中可以包含指向相应检验项目申请之中所提供的原始临床信息的链接。">
+					fhir_mapping = <"*DiagnosticReport.requestDetail.clinicalNotes(en)">
+				>
+				["at0101"] = <
+					text = <"注释">
+					description = <"关于其他字段之中并未采集/记录的，关于当前检验结果的其他文字叙述型内容。">
+				>
+				["at0106"] = <
+					text = <"原始申请检验项目名称">
+					description = <"所申请的原始实验室检验项目的名称。">
+					comment = <"当所申请的检验项目与实验室实际执行的检验项目不同时，应当会用到本数据元。">
+				>
+				["at0107"] = <
+					text = <"已登记">
+					description = <"表示当前检验项目的存在情况已在实验室信息系统之中进行了登记，但目前尚无任何可用的信息。">
+				>
+				["at0110"] = <
+					text = <"检验详情">
+					description = <"关于所采用的分析方法、仪器设备或解释的结构化详情。">
+					comment = <"例如：关于ELISA/散射比浊法的详情。">
+				>
+				["at0111"] = <
+					text = <"床旁检验项目">
+					description = <"此项数据元旨在表明当前的检验项目究竟是床旁（Point-of-Care，POCT）直接进行的检验项目，而不是实验室或其他服务机构/部门/科室所提供的正式结果。">
+					comment = <"如果当前的检验项目是在是床旁（Point-of-Care，POCT）直接进行的，则取值为真（True）。">
+				>
+				["at0112"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0113"] = <
+					text = <"混杂因素">
+					description = <"影响当前监测/测量结果或检验结果准确解释的问题或情况。">
+					comment = <"应当将混杂因素数据元“”保留用于那些可能影响结果解释的，患者状态/生理[机能]的未加控制/意外的问题，如 '近期的锻炼' 或 '近期的吸烟'。
+
+对于已知或所需的前提条件，如“禁食”，应当采用群簇型标本原始型（CLUSTER.specimen）之中的采样条件数据元'Sampling conditions' 来加以记录。在某些情况下，可能会将前提条件作为检验项目名称的一部分来加以记录，如 '空腹血糖'。
+
+对于标本采集或处理方面的已知问题，如“止血带使用时间过长”或“标本溶血”，应当采用群簇型标本原始型（CLUSTER.specimen）之中的标本质量数据元'Sampling conditions'元素来加以记录。
+
+最好尽可能采用特定的术语标准来加以编码。">
+				>
+				["at0114"] = <
+					text = <"结构化混杂因素">
+					description = <"关于那些影响检测/测量结果或检验结果准确解释的问题或情况的详情。">
+					comment = <"例如：最后一次正常的月经周期 (Last Normal Menstrual Period，LNMP)。">
+				>
+				["at0115"] = <
+					text = <"经过更正">
+					description = <"结果在达到最终状态之后已被修改，是完整的结果，经过了负责的病理学工作人员的核对。这是“经过修正”类别的一个子类别。">
+				>
+				["at0116"] = <
+					text = <"错误录入">
+					description = <"当前检验结果在此前最终发布之后已被撤销。">
+				>
+				["at0117"] = <
+					text = <"扩展">
+					description = <"采集本地内容或者实现与其他参考模型/形式化体系之间进行协调统一所额外需的其他信息。">
+					comment = <"例如：旨在实现与FHIR或CIMI等效项进行协调统一的，本地信息需求或额外的元数据。">
+				>
+				["at0118"] = <
+					text = <"多媒体表现">
+					description = <"表现当前检验结果的数字图像、视频或图表。">
+					comment = <"允许采用多种的格式，但它们应当都表现的是等价的临床内容。">
+					fhir_mapping = <"*DiagnosticReport.presentedForm(en)">
+				>
+				["at0119"] = <
+					text = <"经过追加">
+					description = <"在达到最终状态之后，因为添加新的内容而造成报告的修改。已有的内容并未发生变更。这是“经过修正”类别的一个子类别。">
+				>
+				["at0120"] = <
+					text = <"初步">
+					description = <"已有经过核对的早期/初步结果可用，但并非所有的结果都属于是最终结果。这是“部分”类别的一个子类别。">
+				>
+				["at0121"] = <
+					text = <"检验方法">
+					description = <"关于进行当前检验项目时所采用的方法的描述。">
+					comment = <"最好尽可能采用特定的术语标准来加以编码。">
+				>
+				["at0122"] = <
+					text = <"结构化检验项目诊断">
+					description = <"当前实验室检验项目的结构化诊断或复杂诊断。">
+					comment = <"例如：由多个不同的轴（如形态学、病因学和功能）所组成的解剖病理学诊断。">
+				>
+			>
+		>
+		["de"] = <
+			items = <
+				["at0000"] = <
+					text = <"Laborergebnis">
+					description = <"Das Ergebnis - einschließlich der Befunde und der Interpretation des Labors - einer Untersuchung, die an Proben durchgeführt wurde, die von einer Einzelperson stammen oder mit dieser Person zusammenhängen.">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Jedes Ereignis">
+					description = <"Jeder Zeitpunkt oder jedes Intervall, das in einem Template oder zur Laufzeit definiert werden kann.">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0005"] = <
+					text = <"Labortest-Bezeichnung">
+					description = <"Name der Laboruntersuchung, die an der/den Probe(n) durchgeführt wurde.">
+					comment = <"Ein Laborergebnis kann sich auf ein einzelnes Analyt oder eine Analytgruppe beziehen. Dazu zählen auch komplette Panel an Parametern. 
+Es wird dringend empfohlen, die \"Labortest-Bezeichnung\" anhand einer Terminologie zu kodiereren, wie zum Beispiel LOINC oder SNOMED CT. Beispiel: \"Glukose\", \"Harnstoff\", \"Abstrich\", \"Cortisol\", \"Leberbiopsie\". Der Name kann u.U. auch das Probenmaterial oder den Patientenstatus (z.B. \"Blutzuckerspiegel nüchtern\") oder andere Informationen beinhalten wie \"Kalium (Blutgas)\".">
+				>
+				["at0017"] = <
+					text = <"Labor, welches den Untersuchungsauftrag annimmt">
+					description = <"Angaben zu dem Labor, das die Anfrage erhalten hat und die Hauptverantwortung für die Verwaltung der Berichterstattung über den Test trägt, auch wenn andere Labore bestimmte Aspekte ausführen.">
+					comment = <"Dieser Slot gibt die Details des Labors an, dass die Anforderung erhalten hat und die Gesamtverantwortung für die Berichterstellung des Tests trägt, selbst wenn andere Labore bestimmte Aspekte ausführen.
+
+Das Empfangslabor kann den Test entweder durchführen oder an ein anderes Labor verweisen. Wenn ein anderes Labor für die Durchführung der Tests mit bestimmten Analyten zuständig ist, ist zu erwarten, dass diese Details im SLOT 'Analyte result detail' innerhalb des Archetyps CLUSTER.laboratory_test_analyte enthalten sind.">
+				>
+				["at0035"] = <
+					text = <"Verteilerliste">
+					description = <"Details über weitere Kliniker oder Organisationen, die eine Kopie der Analyseergebnisse benötigen.">
+					comment = <"Die \"Verteilerliste\" dient nur zu Informationszwecken. Der Hauptempfänger des Berichts ist die Person, die dazu bestimmt ist, auf die Information zu reagieren.">
+				>
+				["at0037"] = <
+					text = <"Teilweise">
+					description = <"Das Testergebnis ist als ein Teilergebnis (z.B. Initial, vorübergehend oder vorläufig) bestätigt: Daten im Testergebnis können unvollständig oder nicht verifiziert sein.">
+				>
+				["at0038"] = <
+					text = <"Final">
+					description = <"Das Testergebnis ist vollständig und durch eine autorisierte Person bestätigt.">
+				>
+				["at0040"] = <
+					text = <"Abgeändert">
+					description = <"Das Ergebnis wurde nach der Finalisierung modifiziert und ist vollständig von dem verantwortlichen Untersucher verifiziert. Die Ergebnisdaten wurden geändert.">
+				>
+				["at0057"] = <
+					text = <"Schlussfolgerung">
+					description = <"Beschreibung der wichtigsten Ergebnisse.">
+					comment = <"Zum Beispiel: \"Das Muster lässt auf eine erhebliche Nierenfunktionsstörung schließen\". Der Inhalt der Zusammenfassung unterscheidet sich je nach durchgeführter Untersuchung. Diese Zusammenfassung sollte mit der kodierten \"Testdiagnose\" übereinstimmen.">
+				>
+				["at0062"] = <
+					text = <"Auftrags-ID des anfordernden/einsendenden Systems">
+					description = <"Lokale Auftrags-ID des anfordernden/einsendenden Systems.">
+					comment = <"Äquivalent zur \"HL7 Placer Order Identifier\".">
+				>
+				["at0063"] = <
+					text = <"Auftrags-ID (Empfänger)">
+					description = <"Lokale Auftrags-ID, die vom auftragsempfangendem System, gewöhnlich dem Laborinformationssystem (LIS) zugewiesen wird.">
+					comment = <"Die Vergabe einer solchen ID ermöglicht das Nachverfolgen des Auftragsstatus und das Verlinken der Ergebnisse zum Auftrag. Es erlaubt auch das Verwalten von weiteren Erkundigungen und Nachfragen und ist äquivalent zum \"HL7 Filler Order Identifier\".">
+				>
+				["at0065"] = <
+					text = <"Probendetail">
+					description = <"Angaben über die Beschaffenheit der analysierten Probe.">
+					comment = <"Wenn der Probentyp mit einem Code in der Testbezeichnung ausreichend spezifiziert ist, sind diese zusätzlichen Daten nicht erforderlich. Die Verknüpfung von Ergebnissen mit bestimmten Proben kann sowohl in einem CLUSTER.Probe als auch in den verschiedenen CLUSTER Archetypen mit Hilfe von Elementen mit der Bezeichnung \"Probe\" dokumentiert werden.
+">
+				>
+				["at0068"] = <
+					text = <"Laborinterne Kennzeichnung">
+					description = <"Eine lokale Kennung, die vom empfangenden Laborinformationssystem (LIS) vergeben wird, um den Testvorgang zu verfolgen.">
+					comment = <"Diese Kennung ist eine vom LIS vergebene interne Trackingnummer und ist nicht als Bezeichnung für den Test gedacht.">
+				>
+				["at0073"] = <
+					text = <"Gesamtteststatus">
+					description = <"Der Status des gesamten Laborprüfergebnisses.">
+					comment = <"Die Werte wurden so ausgewählt, dass sie mit denen im HL7 FHIR Diagnosebericht übereinstimmen, der historisch aus der HL7v2Praxis stammt. Andere lokale Codes/Begriffe können über den Text \"Auswahl\" verwendet werden. 
+
+Dieses Element kann mehrfach vorkommen, um Fälle abzudecken, bei denen der Status für verschiedene Aspekte des Ergebnisses in mehrere Elemente unterteilt wurde.
+">
+				>
+				["at0074"] = <
+					text = <"Abgebrochen">
+					description = <"Das Ergebnis ist nicht verfügbar, weil der Test nicht gestartet oder nicht abgeschlossen wurde (manchmal auch als \"gescheitert\" bezeichnet).">
+				>
+				["at0075"] = <
+					text = <"Zeitstempel des gesamten Teststatus">
+					description = <"Zeitpunkt an dem das Ergebnis für den oben genannten \"Gesamtteststatus\" ausgegeben wurde.">
+				>
+				["at0077"] = <
+					text = <"Diagnostische Organisationseinheit">
+					description = <"Die diagnostische Organisationseinheit oder die Labordisziplin, die für das Laborergebnis verantwortlich ist.">
+					comment = <"Dies soll eine allgemeine Kategorisierung sein und nicht den organisatorischen Namen des Labors erfassen. Zum Beispiel anatomische Pathologie, Immunologie und Transfusionsmedizin, medizinische Mikrobiologie, klinische Pharmakologie, medizinische Genetik, medizinische Biochemie. Alternativ noch granuläre Subkategorien, wie z.B. Hormone/Endokrinologie, Hämatologie, Autoantikörper, Allergologie. Diese Datenelemente helfen bei der Filterung nach breiten Kategorien von Ergebnissen gemäß den lokalen Gegebenheiten. Dieses Datenelement sollte, wenn möglich, mit einer Terminologie kodiert werden.">
+				>
+				["at0090"] = <
+					text = <"Einsender">
+					description = <"Details über den Kliniker oder die Abteilung, die das Labortestergebnis angefordert hat.">
+				>
+				["at0094"] = <
+					text = <"Details der Testanforderung">
+					description = <"Details zur Testanforderung.">
+					comment = <"In den meisten Fällen gibt es eine Testanfrage und ein einzelnes entsprechendes Testergebnis. Jedoch ermöglicht dieser wiederholte Cluster die Situation, dass mehrere Testanfragen mit einem einzigen Testergebnis gemeldet werden können.
+
+Als Beispiel: \"Ein Arzt fordert in einer Anfrage Blutzucker und in einer zweiten Anfrage Harnstoff/Elektrolyte an, aber das Laboranalysegerät führt beides durch und das Labor möchte diese zusammen melden\".">
+				>
+				["at0097"] = <
+					text = <"Testergebnis">
+					description = <"Ergebnisse der durchgeführten Untersuchungen an der/den Probe(n).">
+					comment = <"Dieser SLOT kann einen einzelnen Analyt, eine Gruppe, ein Panel oder eine Reihe von mehreren Analyten oder eine komplexere und spezifischere Struktur tragen.">
+				>
+				["at0098"] = <
+					text = <"Testdiagnose">
+					description = <"Kurze Beschreibung der klinischen Bedeutung und der Aussagekraft des Laborergebnisses.">
+					comment = <"Zum Beispiel: \"Schwere hepatische Beeinträchtigung\", \"Salmonellenbefall\". Die Kodierung der Diagnose mit einer Terminologie, wird nach Möglichkeit dringend empfohlen. Die Diagnose soll zu der Beschreibung im Datenelement \"Zusammenfassung\" passen.">
+				>
+				["at0100"] = <
+					text = <"Vorhandene klinische Information">
+					description = <"Beschreibung der klinischen Informationen, die zum Zeitpunkt der Auswertung der Ergebnisse verfügbar sind.">
+					comment = <"Dieses Datenelement kann einen Link zu den ursprünglichen klinischen Informationen enthalten, die in der Testanforderung angegeben sind.">
+				>
+				["at0101"] = <
+					text = <"Kommentar">
+					description = <"Weitere Informationen über das Laborergebnis, welche bisher nicht in den anderen Feldern erfasst wurden.">
+				>
+				["at0106"] = <
+					text = <"Originaler Name der angeforderten Testung">
+					description = <"Name des ursprünglich angeforderten Tests.">
+					comment = <"Dieses Datenelement ist zu verwenden, wenn die angeforderte Testung von der tatsächlich vom Labor durchgeführten Testung abweicht.">
+				>
+				["at0107"] = <
+					text = <"Registriert">
+					description = <"Der Labortest wurde im Laborinformationssystem registriert, aber es ist derzeit noch nichts verfügbar.">
+				>
+				["at0110"] = <
+					text = <"Test Details">
+					description = <"Strukturierte Details über die beim Labortest verwendete Methodik, das Gerät oder die Auswertung.">
+					comment = <"Zum Beispiel: \"Details der ELISA/Nephelometrie\".">
+				>
+				["at0111"] = <
+					text = <"Point-of-care Test">
+					description = <"Dies gibt an, ob der Test direkt am Point-of-Care (POCT) durchgeführt wurde, im Gegensatz zu einem formalen Ergebnis eines Labors oder einer anderen Dienstleistungsorganisation.">
+					comment = <"Wahr, wenn der Test direkt am Point-of-Care (POCT) durchgeführt wurde.">
+				>
+				["at0112"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0113"] = <
+					text = <"Störfaktoren">
+					description = <"Probleme oder Umstände, die sich auf die genaue Interpretation der Messung oder des Testergebnisses auswirken.">
+					comment = <"\"Störfaktoren\", die die Interpretation beeinflussen könnten wie z.B. \"kürzliches Training\" oder \"neuer Tabakkonsum\" sollten für unkontrollierte/ungeplante Probleme des Patientenzustands/ der Physiologie vorgesehen werden.
+
+Bekannte oder erforderliche Voraussetzungen, wie z.B. \"Fasten\", sollten im Element \"Probenbedingungen\" innerhalb des CLUSTER.Probe-Archetyps aufgeführt werden. In einigen Fällen werden Voraussetzungen als Teil des Testnamens erfasst, z.B. \"Nüchternblutzucker\".
+
+Bekannte Schwierigkeiten bei der Probenentnahme oder -behandlung, wie z.B. die \"verlängerte Anwendung von Tourniquet\" oder \"hämolysierte Probe\", sollten in den Elementen \"Probenqualität\" innerhalb des CLUSTER.Probe-Archetyps aufgeführt werden.">
+				>
+				["at0114"] = <
+					text = <"Strukturierte Erfassung der Störfaktoren">
+					description = <"Einzelheiten zu Problemen oder Umständen, die sich auf die genaue Interpretation der Messung oder des Prüfergebnisses auswirken.">
+					comment = <"Zum Beispiel: Letzte normale Menstruationsperiode (LNMP).">
+				>
+				["at0115"] = <
+					text = <"Korrigiert">
+					description = <"Das Ergebnis wurde nach der Finalisierung modifiziert und ist vollständig vom verantwortlichen Untersucher verifiziert. Dies ist eine Unterkategorie von \"Abgeändert\".">
+				>
+				["at0116"] = <
+					text = <"Irrtümlich eingegeben">
+					description = <"Das Testergebnis wurde nach der vorherigen Endfreigabe zurückgezogen.">
+				>
+				["at0117"] = <
+					text = <"Erweiterung">
+					description = <"Weitere Informationen, die erforderlich sind, um lokale Inhalte abzubilden oder das Modell an andere Referenzmodelle anzupassen.">
+					comment = <"Zum Beispiel: Lokaler Informationsbedarf oder zusätzliche Metadaten, um ein Mapping auf FHIR oder CIMI Modelle zu ermöglichen.">
+				>
+				["at0118"] = <
+					text = <"Multimedia-Darstellung">
+					description = <"Bild, Video oder Diagramm zur Visualisierung des Testergebnisses.">
+					comment = <"Mehrere Formate sind erlaubt - diese sollten aber einen äquivalenten klinischen Inhalt darstellen.">
+				>
+				["at0119"] = <
+					text = <"Hinzugefügt">
+					description = <"Nach der endgültigen Fassung wurde der Bericht durch Hinzufügen neuer Inhalte aktualisiert. Der bestehende Inhalt bleibt unverändert. Dies ist eine Unterkategorie von \"Abgeändert\".">
+				>
+				["at0120"] = <
+					text = <"Vorläufig">
+					description = <"Es sind erste, bestätigte Ergebnisse verfügbar, aber nicht alle Ergebnisse sind final. Dies ist eine Unterkategorie von \"Teilweise\".">
+				>
+				["at0121"] = <
+					text = <"Testmethode">
+					description = <"Die Beschreibung der Methode, mit dem der Test durchgeführt wurde.">
+					comment = <"Wenn möglich, ist eine Kodierung mit einer Terminologie wünschenswert.">
+				>
+				["at0122"] = <
+					text = <"Strukturierte Testdiagnostik">
+					description = <"Eine strukturierte oder komplexe Diagnose für die Laboruntersuchung.">
+					comment = <"Zum Beispiel: Anatomische Pathologiediagnosen, die aus mehreren verschiedenen Schwerpunkten wie Morphologie, Ätiologie und Funktion zusammengesetzt sind.">
+				>
+			>
+		>
+		["it"] = <
+			items = <
+				["at0000"] = <
+					text = <"Risultato di esame di laboratorio">
+					description = <"L'esito, inclusi i risultati e l'interpretazione, di una indagine di laboratorio effettuata su campioni provenienti da individui o relativi materiali.">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Qualunque evento">
+					description = <"Predefinito, non specificato istante o intervallo di tempo, che può essere esplicitamente dettagliato in un template o in esecuzione (tempo reale)">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0005"] = <
+					text = <"Nome dell'esame">
+					description = <"Nome dell' indagine di laboratorio effettuata sul campione/i.">
+					comment = <"Il risultato di un esame può essere relativo ad un singolo analita, oppure and un gruppo di elementi, inclusi i panel test. Si raccomanda vivamente di codificare il nome dell'esame tramite utilizzo di una terminologia, come ad esempio LOINC o SNOMED CT. Ad esempio: 'Glucosio', 'Urea ed elettroliti', 'Tampone', 'Cortisolo (am)', 'Potassio nella traspirazione' o 'Istopatologia del melanoma'. Il nome può talvolta includere il tipo di campione e lo stato del paziente, ad esempio 'Glucosio a digiuno' o includere altre informazioni, come 'Potassio (gas sanguigni PNA).">
+				>
+				["at0017"] = <
+					text = <"Laboratorio ricevente">
+					description = <"Dettagli riguardanti il laboratorio che ha ricevuto la richiesta ed ha la piena responsabilità di gestione del risultato dell'esame, anche nel caso in cui altri laboratori abbiano  eseguito specifiche parti.">
+					comment = <"Questo campo viene utilizzato per indicare i dettagli riguardanti il laboratorio che ha ricevuto la richiesta ed ha la piena responsabilità di gestione del risultato dell'esame, anche nel caso  in cui altri laboratori ne abbiano eseguito delle specifiche parti. Il laboratorio ricevente potrebbe sia effettuare l'esame, oppure delegarlo verso un altro laboratorio. Quando un altro laboratorio è responsabile dell'esecuzione del test su degli specifici analiti, ci si aspetta che  i relativi dettagli vengano riportati nello SLOT \"Dettagli del risultato dell'analita\", all'interno dell'archetipo CLUSTER.laboratory_test_analyte.">
+				>
+				["at0035"] = <
+					text = <"Lista di distribuzione">
+					description = <"Dettagli su eventuale altro personale sanitario o organismi che hanno richiesto una copia del risultato dell'esame. ">
+					comment = <"La \"Lista di distribuzione\" ha soltanto scopo informativo, ed il destinatario principale della lista è la persona ritenuta quella preposta ad agire sulle informazioni.">
+				>
+				["at0037"] = <
+					text = <"Parziale">
+					description = <"E' un risltato parziale(iniziale, provvisorio o preliminare) dell'esame: la data nel risultato dell'esame potrebbe essere incompleta, oppure non verificata.">
+				>
+				["at0038"] = <
+					text = <"Definitivo">
+					description = <"Il risultato dell'esame è completo ed è stato verificato da una persona autorizzata. ">
+				>
+				["at0040"] = <
+					text = <"Modificato">
+					description = <"Il risultato è stato modificato dopo essere stato dichiarato come Definitivo, ed è completo e verificato dal patologo responsabile e data dell'esito è stata cambiata. ">
+				>
+				["at0057"] = <
+					text = <"Conclusioni">
+					description = <"Descrizione relativa agli esiti principali. ">
+					comment = <"Per esempio: \"l'esito indica una significativa compromissione renale\". Il contenuto delle conclusioni può variare, a seconda dell'indagine effettuata. Queste conclusioni dovrebbero essere allineate con quanto riportato nel campo \"Diagnosi dell'esame\".">
+				>
+				["at0062"] = <
+					text = <"Identificativo del richiedente l'ordine">
+					description = <"ID locale assegnato all'ordine dell'esame dal sistema che lo ha richiesto ">
+					comment = <"E' equivalente al campo HL7 \"Placer Order Identifier\"">
+				>
+				["at0063"] = <
+					text = <"Identificativo del ricevente l'ordine">
+					description = <"Identificativo locale assegnato all'ordine dell'esame dall'order filler, solitamente dal Sistema Informativo di Laboratorio (LIS).">
+					comment = <"L'identificativo assegnato alla richiesta dal Sistema Informativo di Laboratorio (LIS) permette di tracciare lo stato di avanzamento della richiesta e di associare i risultati alle richieste. Fornisce anche un riferimento utile nelle indagini e di solito è equivalente al campo HL7 \"Filler Order Identifier\".">
+				>
+				["at0065"] = <
+					text = <"Dettagli sul campione">
+					description = <"Dettagli sulla sostanza fisica che è stata analizzata. ">
+					comment = <"Se il tipo del campione è specificato in maniera esaustiva all'interno del nome dell'esame, allora non è richiesto alcun dettaglio. Nel caso di campioni multipli, questi possono essere rappresentati mediante \"gruppo di risultati\" (\"Result group\").">
+				>
+				["at0068"] = <
+					text = <"Identificativo interno del laboratorio">
+					description = <"Identificativo locale assegnato dal Sistema Informativo di Laboratorio (LIS) ricevente, allo scopo di tracciare il processo dell'esame. ">
+					comment = <"Questo identivicativo è un numero di tracciabilità interno assegnato dal LIS, e non il nome dell'esame. ">
+				>
+				["at0073"] = <
+					text = <"Stato complessivo dell'esame">
+					description = <"Lo stato relativo all'esame di laboratorio nel suo complesso. ">
+					comment = <"I valori sono stati specificatamente scelti in moto tale da corrispondere a quelli del \"FHIR Diagnostic Report\" di HL7, a loro volta storicamente derivanti dal HL7 v2. Altre codifiche/terminologie locali possono essere utilizzare tramite la scelta \"Text\". Questo elemento ha occorrenze multiple al fine di soddisfare le esigenze di quegli use case in cui gli stati relativi a differenti aspetti del risultato sono stati divisi in più componenti.">
+				>
+				["at0074"] = <
+					text = <"Cancellato">
+					description = <"Il risultato non è disponibile perché il test non è stato avviato o non è stato completato (talvolta chiamato anche 'abortito').">
+				>
+				["at0075"] = <
+					text = <"Timestamp dello stato generale del test">
+					description = <"La data e/o l'ora in cui è stato rilasciato lo \"Stato complessivo dell'esame\". ">
+				>
+				["at0077"] = <
+					text = <"Categoria di servizio diagnostico">
+					description = <"Il servizio diagnostico o la disciplina che è responsabile del risultato del test di laboratorio.">
+					comment = <"Questa vuole essere una categorizzazione generale e non registrare il nome organizzativo del laboratorio. Per esempio: anatomia patologica, immunologia e medicina trasfusionale, microbiologia medica, farmacologia clinica, genetica medica, biochimica medica. In alternativa possono essere utilizzate sottocategorie o sottodiscipline più granulari, come endocrinologia, ematologia e servizi di allergologia. Questo può aiutare i medici a filtrare tra le categorie di risultati. La codifica con una terminologia è auspicabile, ove possibile.">
+				>
+				["at0090"] = <
+					text = <"Richiedente">
+					description = <"Dettagli del clinico o dell'organizzazione che richiede il risultato dell'esame di laboratorio.">
+				>
+				["at0094"] = <
+					text = <"Dettagli della richiesta di test">
+					description = <"Dettagli sulla richiesta di test.">
+					comment = <"Nella maggior parte delle situazioni c'è una richiesta di test e un singolo risultato di test corrispondente, tuttavia questo cluster di ripetizione permette la situazione in cui ci possano essere richieste di test multipli segnalati utilizzando un singolo risultato di test.
+
+Come esempio: \"un clinico chiede il glucosio nel sangue in una richiesta e gli urei/elettroliti in una seconda richiesta, ma l'analizzatore di laboratorio fa entrambe le cose e il laboratorio desidera riportare queste richieste insieme\".">
+				>
+				["at0097"] = <
+					text = <"Risultati del test">
+					description = <"Risultati del test eseguito sul campione o sui campioni.">
+					comment = <"Questo SLOT può riportare un singolo analita, un gruppo, un pannello o una batteria di più analiti, o una struttura più complessa e specifica.">
+				>
+				["at0098"] = <
+					text = <"Diagnosi del test">
+					description = <"Singola parola, frase o breve descrizione che rappresenta il significato clinico e la significatività del risultato del test di laboratorio.">
+					comment = <"Per esempio: 'Grave insufficienza epatica', 'Contaminazione da Salmonella'. Si raccomanda vivamente, ove possibile, di codificare la diagnosi con una terminologia. Questa diagnosi dovrebbe essere allineata con la narrazione nella 'Conclusione'.">
+				>
+				["at0100"] = <
+					text = <"Informazioni cliniche fornite">
+					description = <"Descrizione delle informazioni cliniche disponibili al momento dell'interpretazione dei risultati.">
+					comment = <"Questo elemento di dati può includere un link alle informazioni cliniche originali fornite nella richiesta di test.">
+				>
+				["at0101"] = <
+					text = <"Commento">
+					description = <"Narrativa aggiuntiva sul risultato del test non catturato in altri campi.">
+				>
+				["at0106"] = <
+					text = <"Nome del test originale richiesto">
+					description = <"Nome del test di laboratorio originale richiesto.">
+					comment = <"Questo elemento deve essere utilizzato quando il test richiesto differisce da quello effettivamente eseguito dal laboratorio.">
+				>
+				["at0107"] = <
+					text = <"Registrato">
+					description = <"L'esistenza del test è registrata nel Sistema Informativo di Laboratorio, ma non c'è ancora nulla di disponibile. ">
+				>
+				["at0110"] = <
+					text = <"Dettagli del test">
+					description = <"Dettagli strutturati sul metodo utilizzato relativamente ad analisi, dispositivi o interpretazione. ">
+					comment = <"Ad esempio: 'dettagli di ELISA/nefelometria'.">
+				>
+				["at0111"] = <
+					text = <"Test al punto di assistenza">
+					description = <"Questo elemento indica se il test è stato eseguito direttamente presso il punto di assistenza (Point-of-Care, POCT), rispetto a un risultato formale di un laboratorio o di un'altra organizzazione che fornisce servizi.">
+					comment = <"Vero se il test è stato eseguito direttamente al punto di assistenza (Point-of-Care, POCT).">
+				>
+				["at0112"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0113"] = <
+					text = <"Fattori di confusione">
+					description = <"Problemi o circostanze che influiscono sull'interpretazione accurata del risultato della misurazione o del test.">
+					comment = <"I \"fattori di confusione\" dovrebbero essere riservati a questioni incontrollate/non pianificate di stato del paziente/fisiologia che potrebbero influenzare l'interpretazione, ad esempio \"esercizio fisico recente\" o \"fumo di tabacco recente\".
+
+Le precondizioni conosciute o richieste, come ad esempio il \"digiuno\", dovrebbero essere riportati nell'elemento \"Condizioni di campionamento\" all'interno dell'archetipo CLUSTER.specimen archetype. In alcuni casi le precondizioni vengono catturate come parte del nome del test, ad esempio \"Glucosio nel sangue a digiuno\".
+
+Problemi noti di raccolta o manipolazione dei campioni, come \"uso prolungato del laccio emostatico\" o \"campione emolizzato\", devono essere riportati negli elementi \"Qualità del campione\" all'interno di CLUSTER.specimen archetype.
+Ove possibile, è auspicabile una codifica con una terminologia.">
+				>
+				["at0114"] = <
+					text = <"Fattori di confusione strutturati">
+					description = <"Dettagli dello stato del paziente che possono alterare l'interpretazione del test di laboratorio.">
+					comment = <"Per esempio: Ultimo periodo mestruale normale (Last Normal Menstrual Period, LNMP).">
+				>
+				["at0115"] = <
+					text = <"Corretto">
+					description = <"Il risultato è stato modificato in seguito all'essere stato dichiarato definitivo, ed è completo e verificato dal patologo responsabile. Questa è una sottocategoria di \"Modificato\"">
+				>
+				["at0116"] = <
+					text = <"Inserito in errore">
+					description = <"Il Risultato del Test è stato ritirato dopo un precedente rilascio Finale.">
+				>
+				["at0117"] = <
+					text = <"Estensione">
+					description = <"Informazioni aggiuntive necessarie per acquisire contenuti locali o per allinearsi con altri modelli/formalismi di riferimento.">
+					comment = <"Ad esempio: requisiti informativi locali o metadati aggiuntivi per allinearsi agli equivalenti FHIR o CIMI.">
+				>
+				["at0118"] = <
+					text = <"Rappresentazione multimediale">
+					description = <"Immagine digitale, video o diagramma che rappresenta il risultato del test.">
+					comment = <"Sono consentiti più formati, ma dovrebbero rappresentare un contenuto clinico equivalente.">
+				>
+				["at0119"] = <
+					text = <"Addizionato">
+					description = <"Dopo essere stato dichiarato definitivo, il rapporto è stato modificato con l'aggiunta di nuovi contenuti. Il contenuto pre-esistente è rimasto invariato. Questa è una sottocategoria di \"Modificato\".">
+				>
+				["at0120"] = <
+					text = <"Preliminare">
+					description = <"I primi risultati verificati sono disponibili, ma non tutti i risultati sono definitivi. Questa è una sottocategoria di 'Parziale'.">
+				>
+				["at0121"] = <
+					text = <"Metodo di test">
+					description = <"Descrizione del metodo utilizzato per eseguire il test.">
+					comment = <"E' auspicabile, ove possibile, codificare con una terminologia.">
+				>
+				["at0122"] = <
+					text = <"Diagnosi strutturata per il test">
+					description = <"Una diagnosi strutturata o complessa per il test di laboratorio.">
+					comment = <"Per esempio: Le diagnosi di anatomia patologica che consistono in molteplici assi diversi, come la morfologia, l'eziologia e la funzione. ">
+				>
+			>
+		>
+		["nl"] = <
+			items = <
+				["at0000"] = <
+					text = <"*Laboratory test result(en)">
+					description = <"*The result, including findings and the laboratory's interpretation, of an investigation performed on specimens collected from an individual or related to that individual.(en)">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"*Any event(en)">
+					description = <"*Default, unspecified point in time or interval event which may be explicitly defined in a template or at run-time.(en)">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0005"] = <
+					text = <"Naam van de Test">
+					description = <"Naam van het laboratorium onderzoek dat vericht is op het specimen.">
+				>
+				["at0017"] = <
+					text = <"*Receiving laboratory(en)">
+					description = <"*Details of the laboratory which received the request and has overall responsibility to manage reporting of the test, even if other labs perform specific aspects.(en)">
+				>
+				["at0035"] = <
+					text = <"*Distribution list(en)">
+					description = <"*Details of additional clinicians or organisations who require a copy of the test result.(en)">
+				>
+				["at0037"] = <
+					text = <"*Partial(en)">
+					description = <"*This is a partial (e.g. initial, interim or preliminary) Test Result: data in the Test Result may be incomplete or unverified.(en)">
+				>
+				["at0038"] = <
+					text = <"*Final(en)">
+					description = <"*The Test result is complete and verified by an authorised person.(en)">
+				>
+				["at0040"] = <
+					text = <"*Amended(en)">
+					description = <"*The result has been modified subsequent to being Final, and is complete and verified by the responsible pathologist, and result data has been changed.(en)">
+				>
+				["at0057"] = <
+					text = <"*Conclusion(en)">
+					description = <"*Narrative description of the key findings.(en)">
+				>
+				["at0062"] = <
+					text = <"*Requester order identifier(en)">
+					description = <"*The local identifier assigned by the requesting clinical system.(en)">
+				>
+				["at0063"] = <
+					text = <"*Receiver order identifier(en)">
+					description = <"*The local identifier assigned to the test order by the order filler, usually by the Laboratory Information System (LIS).(en)">
+				>
+				["at0065"] = <
+					text = <"*Specimen detail(en)">
+					description = <"*Details about the physical substance that has been analysed.(en)">
+				>
+				["at0068"] = <
+					text = <"*Laboratory internal identifier(en)">
+					description = <"*A local identifier assigned by the receiving Laboratory Information System (LIS) to track the test process.(en)">
+				>
+				["at0073"] = <
+					text = <"*Overall test status(en)">
+					description = <"*The status of the laboratory test result as a whole.(en)">
+				>
+				["at0074"] = <
+					text = <"*Cancelled(en)">
+					description = <"*The result is unavailable because the test was not started or not completed (also sometimes called 'aborted').(en)">
+				>
+				["at0075"] = <
+					text = <"*Overall test status timestamp(en)">
+					description = <"*The date and/or time that ‘Overall test status’ was issued.(en)">
+				>
+				["at0077"] = <
+					text = <"*Diagnostic service category(en)">
+					description = <"*The diagnostic service or discipline that is responsible for the laboratory test result.(en)">
+				>
+				["at0090"] = <
+					text = <"*Requester(en)">
+					description = <"*Details of the clinician or organisation requesting the laboratory test result.(en)">
+				>
+				["at0094"] = <
+					text = <"*Test request details(en)">
+					description = <"*Details about the test request.(en)">
+				>
+				["at0097"] = <
+					text = <"*Test result(en)">
+					description = <"*Results of the test performed on the specimen(s).(en)">
+				>
+				["at0098"] = <
+					text = <"*Test diagnosis(en)">
+					description = <"*Single word, phrase or brief description that represents the clinical meaning and significance of the laboratory test result.(en)">
+				>
+				["at0100"] = <
+					text = <"*Clinical information provided(en)">
+					description = <"*Description of clinical information available at the time of interpretation of results.(en)">
+				>
+				["at0101"] = <
+					text = <"*Comment(en)">
+					description = <"*Additional narrative about the test result not captured in other fields.(en)">
+				>
+				["at0106"] = <
+					text = <"*Original test requested name(en)">
+					description = <"*Name of the original laboratory test requested.(en)">
+				>
+				["at0107"] = <
+					text = <"*Registered(en)">
+					description = <"*The existence of the test is registered in the Laboratory Information System, but there is nothing yet available.(en)">
+				>
+				["at0110"] = <
+					text = <"*Testing details(en)">
+					description = <"*Structured details about the method of analysis, device or interpretation used.(en)">
+				>
+				["at0111"] = <
+					text = <"*Point-of-care test(en)">
+					description = <"*This indicates whether the test was performed directly at Point-of-Care (POCT) as opposed to a formal result from a laboratory or other service delivery organisation.(en)">
+				>
+				["at0112"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0113"] = <
+					text = <"*Confounding factors(en)">
+					description = <"*Issues or circumstances that impact on the accurate interpretation of the measurement or test result.(en)">
+				>
+				["at0114"] = <
+					text = <"*Structured confounding factors(en)">
+					description = <"*Details of issues or circumstances that impact on the accurate interpretation of the measurement or test result.(en)">
+				>
+				["at0115"] = <
+					text = <"*Corrected(en)">
+					description = <"*The result has been modified subsequent to being Final, and is complete and verified by the responsible pathologist. This is a sub-category of 'Amended'.(en)">
+				>
+				["at0116"] = <
+					text = <"*Entered in error(en)">
+					description = <"*The Test Result has been withdrawn following previous Final release.(en)">
+				>
+				["at0117"] = <
+					text = <"*Extension(en)">
+					description = <"*Additional information required to capture local content or to align with other reference models/formalisms.(en)">
+				>
+				["at0118"] = <
+					text = <"*Multimedia representation(en)">
+					description = <"*Digital image, video or diagram representing the test result.(en)">
+				>
+				["at0119"] = <
+					text = <"*Appended(en)">
+					description = <"*Subsequent to being final, the report has been modified by adding new content. The existing content is unchanged. This is a sub-category of 'Amended'.(en)">
+				>
+				["at0120"] = <
+					text = <"*Preliminary(en)">
+					description = <"*Verified early results are available, but not all results are final. This is a sub-category of 'Partial'.(en)">
+				>
+				["at0121"] = <
+					text = <"*Test method(en)">
+					description = <"*Description about the method used to perform the test.(en)">
+				>
+				["at0122"] = <
+					text = <"*Structured test diagnosis(en)">
+					description = <"*A structured or complex diagnosis for the laboratory test.(en)">
+				>
+			>
+		>
+		["sv"] = <
+			items = <
+				["at0000"] = <
+					text = <"Laboratorieresultat">
+					description = <"Resultatet av en undersökning, inklusive fynd och laboratoriets tolkning, utförd på provmaterial från en individ eller relaterad till individen. Exempel på provmaterial relaterat till individen kan vara fostervattenprov där provet tas från mammans kropp men provet avser fostret.">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Ospecificerad händelse">
+					description = <"Ospecificerad standardhändelse vid en tidpunkt eller inom ett tidsintervall som explicit kan definieras i en mall eller genereras automatiskt av vissa IT-system.">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0005"] = <
+					text = <"Undersökningsnamn">
+					description = <"Namnet på den laboratorieundersökning eller -analys som utförts på provmaterialet.">
+					comment = <"Undersökningsnamnet kan täcka ett enda resultat eller en grupp resultat. Analysnamnet kan kodas med medicinska kodningssystem som NPU, LOINC, SNOMED CT eller lokala laboratoriekodningssystem. Exempel kan vara \"P-Glukos\", \"Blodgas\", \"Klorid i svett\", \"Kortisol (morgon)\" eller \"Histopatologi malignt melanom\". Namnet kan ibland innehålla typen av provmaterial och patientstatus, såsom \"fP-Glukos\" eller innehålla annan information, såsom \"pO2 (PNA-blodgas)\".">
+				>
+				["at0017"] = <
+					text = <"Ansvarigt laboratorium">
+					description = <"Detaljer om det laboratorium som har mottagit beställningen och som har det övergripande ansvaret för att hantera rapporteringen av undersökningen, även om andra laboratorier utför specifika delar av beställningen.">
+					comment = <"Denna SLOT är avsedd för detaljer om det laboratorium som har mottagit beställningen och som har det övergripande ansvaret för att lämna in en resultatrapport, även om andra laboratorier utför specifika delar av den.
+
+Det ansvariga laboratoriet kan antingen utföra undersökningarna själv eller vidarebefordra dem till andra laboratorier. Om ett annat laboratorium har utfört specifika undersökningar ska information om detta beskrivas i SLOT \"Detaljer om analysresultat\" i arketypen CLUSTER.laboratory_test_analyte.
+">
+				>
+				["at0035"] = <
+					text = <"Distributionslista">
+					description = <"Detaljer om ytterligare kliniker eller organisationer som behöver en kopia av undersökningsresultatet.">
+					comment = <"Personerna eller organisationerna på distributionslistan får endast svaret för information, och det är huvudmottagaren av rapporten som förväntas agera på den.">
+				>
+				["at0037"] = <
+					text = <"Partiell">
+					description = <"Detta är ett partiellt undersökningsresultat, dvs. initialt, interim eller preliminärt. Resultatdata kan vara ofullständiga eller obekräftade.">
+				>
+				["at0038"] = <
+					text = <"Slutgiltig">
+					description = <"Undersökningsresultatet är fullständigt och verifierat av ansvarig person alternativt autoverifierat maskinellt.">
+				>
+				["at0040"] = <
+					text = <"Reviderad">
+					description = <"Det slutgiltiga undersökningsresultatet har reviderats. Denna status har underkategorierna \"Rättad\" och \"Utökad\".">
+				>
+				["at0057"] = <
+					text = <"Tolkning av resultat">
+					description = <"Berättande textuell beskrivning av de viktigaste resultaten.">
+					comment = <"Till exempel \"resultat indikerar signifikant nedsatt njurfunktion\". Tolkningen av resultatet kommer att variera beroende på vilken undersökning som har genomförts. Slutsatsen ska vara i enlighet med de koder som används i dataelementet \"Undersökningsdiagnos\".">
+				>
+				["at0062"] = <
+					text = <"Beställarens beställningsidentifierare">
+					description = <"Den lokala identifierare som tilldelats av det begärande kliniska systemet.">
+					comment = <"Denna identifierare benämns ofta som remissidentifierare, och motsvarar HL7 \"Placer Order Identifier\".">
+				>
+				["at0063"] = <
+					text = <"Mottagarens beställningsidenitifierare">
+					description = <"Den lokala identifierare som tilldelats beställningen av ordermottagningssystemet, vanligtvis av laboratorieinformationssystemet (LIS).">
+					comment = <"Tilldelningen av en identifierare i LIS möjliggör spårning av beställningens status och länkning av resultaten till beställningen. Det tillåter också hantering av ytterligare förfrågningar och motsvarar \"HL7 Filler Order Identifier\".">
+				>
+				["at0065"] = <
+					text = <"Detaljer om provmaterialet">
+					description = <"Detaljer om det provmaterial som har analyserats.">
+					comment = <"Om provmaterialet är tillräckligt specificerat med en kod i undersökningssnamnet är detta dataelement inte nödvändigt. Det är möjligt att länka svar till specifika prover med hjälp av dataelementen för prov-ID i både CLUSTER.Specimen och olika CLUSTER-arketyper för laboratoriesvar.">
+				>
+				["at0068"] = <
+					text = <"Laboratoriets interna identifierare">
+					description = <"En lokal identifierare som tilldelats av det mottagande laboratorieinformationssystemet (LIS) för att spåra analysprocessen.">
+					comment = <"Denna identifierare är ett internt spårningsnummer som tilldelats av LIS och är inte avsett att vara namnet på undersökningen.">
+				>
+				["at0073"] = <
+					text = <"Status undersökningsresultat">
+					description = <"Status för undersökningsresultaten som helhet.">
+					comment = <"Värdena har valts specifikt för att motsvara värdena i HL7 FHIR-resursen \"Diagnostic Report\", som historiskt kommer från HL7 v2. Andra lokala koder eller termer kan användas med datatypen \"Fri eller kodad text\".
+
+Detta element kan upprepas för att stödja applikationer där status för olika aspekter av resultatet delas in i flera element.">
+				>
+				["at0074"] = <
+					text = <"Avbruten">
+					description = <"Resultatet är inte tillgängligt eftersom undersökningen inte har startats eller inte slutförts.">
+				>
+				["at0075"] = <
+					text = <"Tidpunkt för status undersökningsresultat">
+					description = <"Datum och tid för utfärdandet av övergripande resultatstatus.">
+				>
+				["at0077"] = <
+					text = <"Laboratoriedisciplin">
+					description = <"Den diagnostiska organisationsenhet, laboratoriedisciplin eller underdisciplin som ansvarar för laboratorieresultatet.
+">
+					comment = <"Detta är tänkt att vara en allmän kategorisering och inte att fånga laboratoriets interna organisation. Till exempel: patologi, immunologi och transfusionsmedicin, medicinsk mikrobiologi, klinisk farmakologi, medicinsk genetik, medicinsk biokemi. Alternativt kan mer detaljerade underkategorier eller underdiscipliner såsom endokrinologi, hematologi och allergologitjänster användas. Detta kan hjälpa kliniker att filtrera mellan resultatkategorier. Kodning med en terminologi är önskvärd, där det är möjligt.
+">
+				>
+				["at0090"] = <
+					text = <"Beställare">
+					description = <"Uppgifter om den kliniker eller organisation som beställt undersökningen.">
+				>
+				["at0094"] = <
+					text = <"Beställningsdetaljer">
+					description = <"Detaljer om beställningen.">
+					comment = <"I de flesta situationer finns det en beställning och ett motsvarande svar, men under vissa omständigheter kan flera beställningar representeras med en enda arketyp för laboratorieresultat.
+
+Till exempel kan en kliniker beställa \"glukos\" och \"urea och elektrolyter\" i separata beställningar och laboratoriet utför båda analyserna, men skickar endast en övergripande resultatrapport.">
+				>
+				["at0097"] = <
+					text = <"Undersökningsresultat">
+					description = <"Resultatet av den undersökning eller analys som utförts på provmaterialet.">
+					comment = <"Denna SLOT kan innehålla resultat för en enda analys, för en grupp analyser eller för en mer komplex och specifik struktur.">
+				>
+				["at0098"] = <
+					text = <"Undersökningsdiagnos">
+					description = <"Ett ord, en fras eller en kort beskrivning som representerar den kliniska betydelsen eller konsekvensen av laboratorietestresultatet.
+">
+					comment = <"Till exempel: \"Allvarligt nedsatt leverfunktion\", \"Akut hepatit B\". Kodning med en terminologi är att föredra där det är möjligt. Undersökningsdiagnosen bör vara i enlighet med texten i \"Tolkning av resultat\".
+
+">
+				>
+				["at0100"] = <
+					text = <"Tillgänglig klinisk information">
+					description = <"Beskrivning av den kliniska information som finns tillgänglig vid tolkningen av resultaten.">
+					comment = <"Detta dataelement kan innehålla en länk till den ursprungliga kliniska informationen i beställningen.
+
+">
+				>
+				["at0101"] = <
+					text = <"Kommentar">
+					description = <"Ytterligare textuell beskrivning som inte registrerats i andra fält.">
+				>
+				["at0106"] = <
+					text = <"Ursprungligt undersökningsnamn">
+					description = <"Namn på den ursprungligen beställda undersökningen eller analysen.">
+					comment = <"Detta dataelement ska användas när den begärda undersökningen eller analysen skiljer sig från det som faktiskt har utförts av laboratoriet.
+">
+				>
+				["at0107"] = <
+					text = <"Registrerad">
+					description = <"Undersökningen är registrerad i laboratorieinformationssystemet, men resultatet finns för närvarande inte.
+
+">
+				>
+				["at0110"] = <
+					text = <"Detaljer om undersökningsmetod">
+					description = <"Strukturerade detaljer om undersökningsmetoden, utrustningen eller tolkningen.">
+					comment = <"Exempelvis \"detaljer om ELISA-analys\".">
+				>
+				["at0111"] = <
+					text = <"Patientnära analys">
+					description = <"Indikerar om analysen utfördes som en patientnära analys (PNA), det vill säga på vårdenhet, istället för en mer formell laboratorietjänst.">
+					comment = <"Sant om analysen utfördes genom patientnära analys (PNA).">
+				>
+				["at0112"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0113"] = <
+					text = <"Möjliga felkällor">
+					description = <"Villkor eller omständigheter som påverkar tolkningen av laboratorieresultatet.">
+					comment = <"\"Möjliga felkällor\" bör reserveras för okontrollerade eller oplanerade förhållanden hos patienten som kan påverka tolkningen av laboratorieresultatet. Till exempel \"nyligen fysisk aktivitet\", \"nyligen rökt tobak\".
+
+Kända antaganden såsom \"fasta\" bör dokumenteras i dataelementet \"Provtagningskontext\" i arketypen CLUSTER.specimen. I vissa fall är sådana antaganden en del av studiens namn, såsom \"Fastande blodglukos\".
+
+Kända förhållanden relaterade till provtagning eller hantering av provet, såsom \"förlängd stas\" eller \"hemolys\" bör dokumenteras i elementet \"Provkvalitet\" i arketypen CLUSTER.specimen.
+
+Kodning med en terminologi är önskvärt där det är möjligt.
+">
+				>
+				["at0114"] = <
+					text = <"Strukturerade möjliga felkällor">
+					description = <"Mer information om problem eller omständigheter som kan påverka tolkningen av mätningen eller testresultatet.">
+					comment = <"Till exempel den sista normala menstruationsperioden.">
+				>
+				["at0115"] = <
+					text = <"Rättad">
+					description = <"Det slutgiltiga undersökningsresultatet har rättats. Detta är en underkategori av \"Reviderad\".">
+				>
+				["at0116"] = <
+					text = <"Felregistrerad">
+					description = <"Undersökningsresultatet har dragits tillbaka efter att ha varit i status \"Slutgiltig\".">
+				>
+				["at0117"] = <
+					text = <"Ytterligare information">
+					description = <"Ytterligare information som krävs för att registrera lokalt definierat innehåll eller för anpassning till andra referensmodeller.
+">
+					comment = <"Exempelvis lokala informationsbehov eller ytterligare metadata för att möjliggöra mappning till FHIR- eller CIMI-modeller.
+">
+				>
+				["at0118"] = <
+					text = <"Multimedia">
+					description = <"Digital bild, video eller diagram som representerar undersökningsresultatet.">
+					comment = <"Flera format är tillåtna, men innehållet i de olika formaten måste representera samma kliniska innehåll.">
+				>
+				["at0119"] = <
+					text = <"Utökat">
+					description = <"Det slutgiltiga undersökningsresultatet har ändrats genom att nytt innehåll har inkluderats. Det befintliga innehållet är oförändrat. Detta är en underkategori av \"Reviderad\".">
+				>
+				["at0120"] = <
+					text = <"Preliminär">
+					description = <"Verifierade tidiga resultat är tillgängliga, men inte alla resultat är slutgiltiga. Detta är en underkategori av status \"Partiell\".">
+				>
+				["at0121"] = <
+					text = <"Undersökningsmetod">
+					description = <"Beskrivning av den metod som använts för att utföra undersökningen eller analysen.">
+					comment = <"Kodning med en terminologi är önskvärt där det är möjligt.">
+				>
+				["at0122"] = <
+					text = <"Strukturerad undersökningsdiagnos">
+					description = <"En strukturerad eller komplex diagnos för laboratorieundersökningen.">
+					comment = <"Exempelvis patologisk anatomisk diagnos bestående av flera olika komponenter som morfologi, etiologi och funktion.">
+				>
+			>
+		>
+		["pt-br"] = <
+			items = <
+				["at0000"] = <
+					text = <"Resultado de exame de laboratório">
+					description = <"O resultado, incluindo achados e a interpretação do laboratório, de uma investigação realizada em amostras coletadas de um indivíduo ou relacionadas a esse indivíduo.">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"*Any event(en)">
+					description = <"*Default, unspecified point in time or interval event which may be explicitly defined in a template or at run-time.(en)">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0005"] = <
+					text = <"*Test name(en)">
+					description = <"*Name of the laboratory investigation performed on the specimen(s).(en)">
+					comment = <"*A test result may be for a single analyte, or a group of items, including panel tests. It is strongly recommended that 'Test name' be coded with a terminology, for example LOINC or SNOMED CT. For example: 'Glucose', 'Urea and Electrolytes', 'Swab', 'Cortisol (am)', 'Potassium in perspiration' or 'Melanoma histopathology'. The name may sometimes include specimen type and patient state, for example 'Fasting blood glucose' or include other information, as 'Potassium (PNA blood gas)'.(en)">
+				>
+				["at0017"] = <
+					text = <"*Receiving laboratory(en)">
+					description = <"*Details of the laboratory which received the request and has overall responsibility to manage reporting of the test, even if other labs perform specific aspects.(en)">
+					comment = <"*This slot is intended to carry details of the laboratory which received the request and has overall responsibility to manage reporting of the test, even if other labs perform specific aspects.
+
+The receiving laboratory may either perform the test or refer it to another laboratory. Where a different laboratory is responsible for performing the testing on specific analytes, it would be expected that these details would be carried in the 'Analyte result detail' SLOT within the CLUSTER.laboratory_test_analyte archetype.
+
+(en)">
+				>
+				["at0035"] = <
+					text = <"*Distribution list(en)">
+					description = <"*Details of additional clinicians or organisations who require a copy of the test result.(en)">
+					comment = <"*The 'Distribution list' is for information-only, and that the primary recipient of the report is the person intended to act on the information.(en)">
+				>
+				["at0037"] = <
+					text = <"*Partial(en)">
+					description = <"*This is a partial (e.g. initial, interim or preliminary) Test Result: data in the Test Result may be incomplete or unverified.(en)">
+				>
+				["at0038"] = <
+					text = <"*Final(en)">
+					description = <"*The Test result is complete and verified by an authorised person.(en)">
+				>
+				["at0040"] = <
+					text = <"*Amended(en)">
+					description = <"*The result has been modified subsequent to being Final, and is complete and verified by the responsible pathologist, and result data has been changed.(en)">
+				>
+				["at0057"] = <
+					text = <"*Conclusion(en)">
+					description = <"*Narrative description of the key findings.(en)">
+					comment = <"*For example: 'Pattern suggests significant renal impairment'. The content of the conclusion will vary, depending on the investigation performed. This conclusion should be aligned with the coded 'Test diagnosis'.(en)">
+				>
+				["at0062"] = <
+					text = <"*Requester order identifier(en)">
+					description = <"*The local identifier assigned by the requesting clinical system.(en)">
+					comment = <"*Equivalent to the HL7 Placer Order Identifier.(en)">
+				>
+				["at0063"] = <
+					text = <"*Receiver order identifier(en)">
+					description = <"*The local identifier assigned to the test order by the order filler, usually by the Laboratory Information System (LIS).(en)">
+					comment = <"*Assigning an identifier to a request by the Laboratory lnformation System (LIS) enables tracking progress of the request and enables linking results to requests. It also provides a reference to assist with enquiries and it is usually equivalent to the HL7 Filler Order Identifier.(en)">
+				>
+				["at0065"] = <
+					text = <"*Specimen detail(en)">
+					description = <"*Details about the physical substance that has been analysed.(en)">
+					comment = <"*If the specimen type is sufficiently specified with a code in the Test name, then this additional data is not required. Linking results to specific specimens may be recorded using 'Specimen identifier' elements in both the CLUSTER.specimen and the various results CLUSTER archetypes.(en)">
+				>
+				["at0068"] = <
+					text = <"*Laboratory internal identifier(en)">
+					description = <"*A local identifier assigned by the receiving Laboratory Information System (LIS) to track the test process.(en)">
+					comment = <"*This identifier is an internal tracking number assigned by the LIS, and it not intended to be the name of the test.(en)">
+				>
+				["at0073"] = <
+					text = <"*Overall test status(en)">
+					description = <"*The status of the laboratory test result as a whole.(en)">
+					comment = <"*The values have been specifically chosen to match those in the HL7 FHIR Diagnostic report, historically derived from HL7v2 practice. Other local codes/terms can be used via the Text 'choice'.
+
+This element is multiple occurrence to cater for the use cases where statuses for different aspects of the result have been split into several elements.(en)">
+				>
+				["at0074"] = <
+					text = <"*Cancelled(en)">
+					description = <"*The result is unavailable because the test was not started or not completed (also sometimes called 'aborted').(en)">
+				>
+				["at0075"] = <
+					text = <"*Overall test status timestamp(en)">
+					description = <"*The date and/or time that ‘Overall test status’ was issued.(en)">
+				>
+				["at0077"] = <
+					text = <"*Diagnostic service category(en)">
+					description = <"*The diagnostic service or discipline that is responsible for the laboratory test result.(en)">
+					comment = <"*This is intended to be a general categorisation and not to capture the organisational name of the laboratory. For example: anatomical pathology, immunology and transfusion medicine, medical microbiology, clinical pharmacology, medical genetics, medical biochemistry. Alternatively more granular sub categories or sub disciplines, such as endocrinology, haematology, and allergology services, may be used. This may assist clinicians in filtering between categories of results. Coding with a terminology is desirable, where possible.(en)">
+				>
+				["at0090"] = <
+					text = <"*Requester(en)">
+					description = <"*Details of the clinician or organisation requesting the laboratory test result.(en)">
+				>
+				["at0094"] = <
+					text = <"*Test request details(en)">
+					description = <"*Details about the test request.(en)">
+					comment = <"*In most situations there is one test request and a single corresponding test result, however this repeating cluster allows for the situation where there may be multiple test requests reported using a single test result.
+
+As an example: 'a clinician asks for blood glucose in one request and Urea/electrolytes in a second request, but the lab analyser does both and the lab wishes to report these together'.(en)">
+				>
+				["at0097"] = <
+					text = <"*Test result(en)">
+					description = <"*Results of the test performed on the specimen(s).(en)">
+					comment = <"*This SLOT may carry an individual analyte, a group, panel or battery of multiple analytes, or a more complex and specific structure.(en)">
+				>
+				["at0098"] = <
+					text = <"*Test diagnosis(en)">
+					description = <"*Single word, phrase or brief description that represents the clinical meaning and significance of the laboratory test result.(en)">
+					comment = <"*For example: 'Severe hepatic impairment', 'Salmonella contamination'. Coding of the diagnosis with a terminology is strongly recommended, where possible. This diagnosis should be aligned with the narrative in the 'Conclusion'.(en)">
+				>
+				["at0100"] = <
+					text = <"*Clinical information provided(en)">
+					description = <"*Description of clinical information available at the time of interpretation of results.(en)">
+					comment = <"*This data element may include a link to the original clinical information provided in the test request.(en)">
+				>
+				["at0101"] = <
+					text = <"*Comment(en)">
+					description = <"*Additional narrative about the test result not captured in other fields.(en)">
+				>
+				["at0106"] = <
+					text = <"*Original test requested name(en)">
+					description = <"*Name of the original laboratory test requested.(en)">
+					comment = <"*This data element is to be used when the test requested differs from the test actually performed by the laboratory.(en)">
+				>
+				["at0107"] = <
+					text = <"*Registered(en)">
+					description = <"*The existence of the test is registered in the Laboratory Information System, but there is nothing yet available.(en)">
+				>
+				["at0110"] = <
+					text = <"*Testing details(en)">
+					description = <"*Structured details about the method of analysis, device or interpretation used.(en)">
+					comment = <"*For example: 'details of ELISA/nephelometry'.(en)">
+				>
+				["at0111"] = <
+					text = <"*Point-of-care test(en)">
+					description = <"*This indicates whether the test was performed directly at Point-of-Care (POCT) as opposed to a formal result from a laboratory or other service delivery organisation.(en)">
+					comment = <"*True if the test was performed directly at Point-of-Care (POCT).(en)">
+				>
+				["at0112"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0113"] = <
+					text = <"*Confounding factors(en)">
+					description = <"*Issues or circumstances that impact on the accurate interpretation of the measurement or test result.(en)">
+					comment = <"*'Confounding factors' should be reserved for uncontrolled/unplanned issues of patient state/physiology that might affect interpretation, for example 'recent exercise' or 'recent tobacco smoking'.
+
+Known or required preconditions, such as 'fasting' should be carried in the 'Sampling conditions' element within the CLUSTER.specimen archetype . In some cases preconditions are captured as part of the test name, for example 'Fasting blood glucose'.
+
+Known issues with specimen collection or handling, such as 'prolonged use of tourniquet' or 'sample haemolysed', should be carried in the 'Specimen quality' elements within CLUSTER.specimen archetype.
+
+Coding with a terminology is desirable, where possible.(en)">
+				>
+				["at0114"] = <
+					text = <"*Structured confounding factors(en)">
+					description = <"*Details of issues or circumstances that impact on the accurate interpretation of the measurement or test result.(en)">
+					comment = <"*For example: Last Normal Menstrual Period (LNMP).(en)">
+				>
+				["at0115"] = <
+					text = <"*Corrected(en)">
+					description = <"*The result has been modified subsequent to being Final, and is complete and verified by the responsible pathologist. This is a sub-category of 'Amended'.(en)">
+				>
+				["at0116"] = <
+					text = <"*Entered in error(en)">
+					description = <"*The Test Result has been withdrawn following previous Final release.(en)">
+				>
+				["at0117"] = <
+					text = <"*Extension(en)">
+					description = <"*Additional information required to capture local content or to align with other reference models/formalisms.(en)">
+					comment = <"*For example: local information requirements or additional metadata to align with FHIR or CIMI equivalents.(en)">
+				>
+				["at0118"] = <
+					text = <"*Multimedia representation(en)">
+					description = <"*Digital image, video or diagram representing the test result.(en)">
+					comment = <"*Multiple formats are allowed but they should represent equivalent clinical content.(en)">
+				>
+				["at0119"] = <
+					text = <"*Appended(en)">
+					description = <"*Subsequent to being final, the report has been modified by adding new content. The existing content is unchanged. This is a sub-category of 'Amended'.(en)">
+				>
+				["at0120"] = <
+					text = <"*Preliminary(en)">
+					description = <"*Verified early results are available, but not all results are final. This is a sub-category of 'Partial'.(en)">
+				>
+				["at0121"] = <
+					text = <"*Test method(en)">
+					description = <"*Description about the method used to perform the test.(en)">
+					comment = <"*Coding with a terminology is desirable, where possible.(en)">
+				>
+				["at0122"] = <
+					text = <"*Structured test diagnosis(en)">
+					description = <"*A structured or complex diagnosis for the laboratory test.(en)">
+					comment = <"*For example: Anatomical pathology diagnoses consisting of several different axes such as morphology, etiology and function.(en)">
+				>
+			>
+		>
+		["es"] = <
+			items = <
+				["at0000"] = <
+					text = <"Resultado de pruebas de laboratorio">
+					description = <"El resultado, incluidas las conclusiones y la interpretación del laboratorio, de una investigación realizada con muestras recogidas de una persona o relacionadas con ella.">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Cualquier evento">
+					description = <"Evento predeterminado, no especificado, en un punto del tiempo o intervalo que puede definirse explícitamente en una plantilla o en tiempo de ejecución.">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0005"] = <
+					text = <"Nombre de la prueba">
+					description = <"Nombre de la investigación de laboratorio realizada en la(s) muestra(s).">
+					comment = <"El resultado de una prueba puede corresponder a un único analito o a un grupo de elementos, incluidas las pruebas de panel. Se recomienda encarecidamente que \"Nombre de la prueba\" se codifique con una terminología, por ejemplo LOINC o SNOMED CT. Por ejemplo: \"Glucosa\", \"Urea y electrolitos\", \"Hisopo\", \"Cortisol (am)\", \"Potasio en la transpiración\" o \"Histopatología del melanoma\". El nombre puede incluir a veces el tipo de muestra y el estado del paciente, por ejemplo 'Glucosa en sangre en ayunas' o incluir otra información, como 'Potasio (gasometría PNA)'.">
+				>
+				["at0017"] = <
+					text = <"Laboratorio receptor">
+					description = <"Datos del laboratorio que ha recibido la solicitud y tiene la responsabilidad general de gestionar la notificación de la prueba, aunque otros laboratorios realicen aspectos específicos.">
+					comment = <"Este slot está destinado a llevar los datos del laboratorio que recibió la solicitud y tiene la responsabilidad general de gestionar la notificación de la prueba, aunque otros laboratorios realicen aspectos específicos.
+
+El laboratorio receptor puede realizar la prueba o remitirla a otro laboratorio. En caso de que un laboratorio diferente sea responsable de realizar las pruebas de analitos específicos, se espera que estos datos se incluyan en el slot \"Detalle del resultado del analito\" del arquetipo CLUSTER.laboratory_test_analyte.">
+				>
+				["at0035"] = <
+					text = <"Lista de distribución">
+					description = <"Datos de otros médicos u organizaciones que necesiten una copia del resultado de la prueba.">
+					comment = <"La \"Lista de distribución\" es meramente informativa, y el destinatario principal del informe es la persona destinada a actuar en función de la información.">
+				>
+				["at0037"] = <
+					text = <"Parcial">
+					description = <"Se trata de un resultado parcial (por ejemplo, inicial, provisional o preliminar): los datos del resultado pueden estar incompletos o sin verificar.">
+				>
+				["at0038"] = <
+					text = <"Definitivo">
+					description = <"El resultado de la prueba está completo y ha sido verificado por una persona autorizada.">
+				>
+				["at0040"] = <
+					text = <"Modificado">
+					description = <"El resultado ha sido modificado con posterioridad a ser Definitivo, y está completo y verificado por el patólogo responsable, y los datos del resultado han sido modificados.">
+				>
+				["at0057"] = <
+					text = <"Conclusión">
+					description = <"Descripción narrativa de las principales conclusiones.">
+					comment = <"Por ejemplo: \"El patrón sugiere una insuficiencia renal significativa\". El contenido de la conclusión variará en función de la investigación realizada. Esta conclusión debe coincidir con el \"Diagnóstico de la prueba\" codificado.">
+				>
+				["at0062"] = <
+					text = <"Identificador del pedido del solicitante">
+					description = <"El identificador local asignado por el sistema clínico solicitante.">
+					comment = <"Equivalente al Depósito de Identificador de Orden de HL7.">
+				>
+				["at0063"] = <
+					text = <"Identificador de la orden del receptor">
+					description = <"El identificador local asignado a la orden de prueba por el cumplimentador de la orden, normalmente por el Sistema de Información del Laboratorio (SIL).">
+					comment = <"La asignación de un identificador a una solicitud por parte del Sistema de Información de Laboratorio (SIL) permite seguir el progreso de la solicitud y relacionar los resultados con las solicitudes. También proporciona una referencia para ayudar con las consultas y suele ser equivalente al identificador HL7 Filler Order Identifier.">
+				>
+				["at0065"] = <
+					text = <"Detalles de la muestra">
+					description = <"Datos sobre la sustancia física analizada.">
+					comment = <"Si el tipo de muestra está suficientemente especificado con un código en el nombre de la prueba, estos datos adicionales no son necesarios. La vinculación de los resultados a muestras específicas puede registrarse utilizando elementos de \"Identificador de muestra\" tanto en CLUSTER.specimen como en los distintos arquetipos CLUSTER de resultados.">
+				>
+				["at0068"] = <
+					text = <"Identificador interno del laboratorio">
+					description = <"Identificador local asignado por el Sistema de Información del Laboratorio receptor (SIL) para seguir el proceso de la prueba.">
+					comment = <"Este identificador es un número de seguimiento interno asignado por el SIL, y no pretende ser el nombre de la prueba.">
+				>
+				["at0073"] = <
+					text = <"Estado general de las pruebas">
+					description = <"El estado del resultado de la prueba de laboratorio en su conjunto.">
+					comment = <"
+Los valores se han elegido específicamente para que coincidan con los del informe HL7 FHIR Diagnostic, derivados históricamente de la práctica HL7v2. Pueden utilizarse otros códigos/términos locales mediante el texto \"choice\".
+
+Este elemento es de ocurrencia múltiple para atender a los casos de uso en los que los estados para diferentes aspectos del resultado se han dividido en varios elementos.">
+				>
+				["at0074"] = <
+					text = <"Cancelado">
+					description = <"El resultado no está disponible porque la prueba no se ha iniciado o no se ha completado (a veces también se denomina \"abortada\").">
+				>
+				["at0075"] = <
+					text = <"Registro de tiempo del estado general de la prueba">
+					description = <"La fecha y/o la hora en que se emitió el \"Estado general de las pruebas\".">
+				>
+				["at0077"] = <
+					text = <"Especialidad médica/clínica">
+					description = <"El servicio o disciplina de diagnóstico responsable del resultado de la prueba de laboratorio.">
+					comment = <"Se trata de una categorización general y no del nombre organizativo del laboratorio. Por ejemplo: anatomía patológica, inmunología y medicina transfusional, microbiología médica, farmacología clínica, genética médica, bioquímica médica. También pueden utilizarse subcategorías o subdisciplinas más granulares, como endocrinología, hematología y servicios de alergología. Esto puede ayudar a los clínicos a filtrar entre categorías de resultados. Siempre que sea posible, es deseable codificar con una terminología.">
+				>
+				["at0090"] = <
+					text = <"Solicitante">
+					description = <"Datos del clínico u organización que solicita el resultado de la prueba de laboratorio.">
+				>
+				["at0094"] = <
+					text = <"Detalles de la solicitud de la prueba">
+					description = <"Detalles sobre la solicitud de la prueba.">
+					comment = <"En la mayoría de las situaciones hay una solicitud de prueba y un único resultado de prueba correspondiente, sin embargo, este grupo de repetición permite la situación en la que puede haber varias solicitudes de prueba notificadas utilizando un único resultado de prueba.
+
+Por ejemplo: \"un clínico solicita glucosa en sangre en una petición y urea/electrolitos en una segunda petición, pero el técnico del laboratorio realiza ambas y el laboratorio desea notificarlas juntas\".">
+				>
+				["at0097"] = <
+					text = <"Resultado de la prueba">
+					description = <"Resultados de la prueba realizada en la(s) muestra(s).">
+					comment = <"Este SLOT puede transportar un analito individual, un grupo, panel o batería de múltiples analitos, o una estructura más compleja y específica.">
+				>
+				["at0098"] = <
+					text = <"Dignóstico de la prueba">
+					description = <"Palabra única, frase o breve descripción que representa el significado clínico y la importancia del resultado de la prueba de laboratorio.">
+					comment = <"Por ejemplo: 'Insuficiencia hepática grave', 'Contaminación por Salmonella'. Se recomienda encarecidamente codificar el diagnóstico con una terminología, siempre que sea posible. Este diagnóstico debe estar alineado con la información registrada en la 'Conclusión'.">
+				>
+				["at0100"] = <
+					text = <"Información clínica facilitada">
+					description = <"Descripción de la información clínica disponible en el momento de la interpretación de los resultados.">
+					comment = <"Este elemento de datos puede incluir un enlace a la información clínica original facilitada en la solicitud de prueba.">
+				>
+				["at0101"] = <
+					text = <"Comentarios">
+					description = <"Información adicional sobre el resultado de la prueba no recogida en otros campos.">
+				>
+				["at0106"] = <
+					text = <"Nombre de la prueba original solicitada">
+					description = <"Nombre de la prueba de laboratorio original solicitada.">
+					comment = <"Este dato se utilizará cuando la prueba solicitada difiera de la prueba realmente realizada por el laboratorio.">
+				>
+				["at0107"] = <
+					text = <"Registrado">
+					description = <"La existencia de la prueba está registrada en el Sistema de Información del Laboratorio, pero aún no hay nada disponible.">
+				>
+				["at0110"] = <
+					text = <"Detalles de la prueba">
+					description = <"Detalles estructurados sobre el método de análisis, dispositivo o interpretación utilizado.">
+					comment = <"Por ejemplo: 'detalles de ELISA/nefelometría'.">
+				>
+				["at0111"] = <
+					text = <"Prueba en el punto de atención sanitaria">
+					description = <"Indica si la prueba se realizó directamente en el punto de atención (POCT), en contraposición a un resultado formal de un laboratorio u otra organización de prestación de servicios.">
+					comment = <"Verdadero si la prueba se realizó directamente en el punto de atención (POCT).">
+				>
+				["at0112"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0113"] = <
+					text = <"Factores de confusión">
+					description = <"Cuestiones o circunstancias que influyen en la interpretación exacta de la medición o del resultado de la prueba.">
+					comment = <"Los \"factores de confusión\" deben reservarse para cuestiones no controladas/no planificadas del estado/fisiología del paciente que puedan afectar a la interpretación, por ejemplo \"ejercicio reciente\" o \"tabaquismo reciente\".
+
+Las condiciones previas conocidas o requeridas, como \"ayuno\", deben incluirse en el elemento \"Condiciones de muestreo\" del arquetipo CLUSTER.specimen. En algunos casos, las condiciones previas forman parte del nombre de la prueba, por ejemplo \"Glucosa en sangre en ayunas\".
+
+Los problemas conocidos de recogida o manipulación de muestras, como \"uso prolongado de torniquete\" o \"muestra hemolizada\", deben incluirse en los elementos \"Calidad de la muestra\" del arquetipo CLUSTER.specimen.
+
+Siempre que sea posible, es deseable codificar con una terminología.">
+				>
+				["at0114"] = <
+					text = <"Factores de confusión estructurados">
+					description = <"Detalles de los problemas o circunstancias que influyen en la interpretación exacta de la medición o del resultado del ensayo.">
+					comment = <"Por ejemplo: Última menstruación normal (LNMP).">
+				>
+				["at0115"] = <
+					text = <"Corregida">
+					description = <"El resultado ha sido modificado con posterioridad a ser Definitivo, y está completo y verificado por el patólogo responsable. Se trata de una subcategoría de \"Modificado\".">
+				>
+				["at0116"] = <
+					text = <"Añadido por error">
+					description = <"El resultado de la prueba se ha retirado tras la publicación final anterior.">
+				>
+				["at0117"] = <
+					text = <"Ampliación">
+					description = <"Información adicional necesaria para captar el contenido local o para alinearse con otros modelos/formalismos de referencia.">
+					comment = <"Por ejemplo: requisitos locales de información o metadatos adicionales para alinearse con los equivalentes de FHIR o CIMI.">
+				>
+				["at0118"] = <
+					text = <"Representación multimedia">
+					description = <"Imagen digital, vídeo o diagrama que representa el resultado de la prueba.">
+					comment = <"Se permiten múltiples formatos, pero deben representar contenidos clínicos equivalentes.">
+				>
+				["at0119"] = <
+					text = <"Anexo">
+					description = <"Tras ser definitivo, el informe se ha modificado añadiendo nuevos contenidos. El contenido existente no se ha modificado. Se trata de una subcategoría de \"Modificado\".">
+				>
+				["at0120"] = <
+					text = <"Preliminar">
+					description = <"Se dispone de resultados preliminares verificados, pero no todos los resultados son definitivos. Se trata de una subcategoría de \"Parcial\".">
+				>
+				["at0121"] = <
+					text = <"Método de prueba">
+					description = <"Descripción del método utilizado para realizar la prueba.">
+					comment = <"En la medida de lo posible, es deseable codificar con una terminología.">
+				>
+				["at0122"] = <
+					text = <"Diagnóstico de prueba estructurado">
+					description = <"Un diagnóstico estructurado o complejo para la prueba de laboratorio.">
+					comment = <"Por ejemplo: Diagnósticos anatomopatológicos que constan de varios ejes diferentes, como la morfología, la etiología y la función.">
+				>
+			>
+		>
+		["ca"] = <
+			items = <
+				["at0000"] = <
+					text = <"Resultat de proves de laboratori">
+					description = <"El resultat, incloses les conclusions i la interpretació del laboratori, d'una investigació realitzada amb mostres recollides o relacionades amb una persona.">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Qualsevol esdeveniment">
+					description = <"Esdeveniment predeterminat, no especificat, en un punt del temps o interval que es pot definir explícitament en una plantilla o en temps d'execució.">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0005"] = <
+					text = <"Nom de la prova">
+					description = <"Nom de la investigació de laboratori realitzada a la(es) mostra(s).">
+					comment = <"El resultat d'una prova pot correspondre a un únic analit o grup d'elements, incloses les proves de panell. Es recomana que \"Nom de la prova\" es codifiqui amb una terminologia, per exemple LOINC o SNOMED CT. Per exemple: \"Glucosa\", \"Urea i electròlits\", \"Hisop\", \"Cortisol (am)\", \"Potasi en la transpiració\" o \"Histopatologia del melanoma\". El nom pot incloure de vegades el tipus de mostra i l'estat del pacient, per exemple 'Glucosa en sang en dejú' o incloure una altra informació, com 'Potasi (gasometria PNA)'.">
+				>
+				["at0017"] = <
+					text = <"Laboratori receptor">
+					description = <"Dades del laboratori que ha rebut la sol·licitud i té la responsabilitat general de gestionar la notificació de la prova, encara que altres laboratoris facin aspectes específics.">
+					comment = <"Aquest slot està destinat a portar les dades del laboratori que va rebre la sol·licitud i té la responsabilitat general de gestionar la notificació de la prova, encara que altres laboratoris facin aspectes específics.
+
+El laboratori receptor pot fer la prova o remetre-la a un altre laboratori. En cas que un laboratori diferent sigui responsable de fer les proves d'analits específics, s'espera que aquestes dades s'incloguin a l'slot \"Detall del resultat de l'analit\" de l'arquetip CLUSTER.laboratory_test_analyte.">
+				>
+				["at0035"] = <
+					text = <"Llista de distribució">
+					description = <"Detalls de metges o organitzacions addicionals que requereixen una còpia del resultat de la prova.">
+					comment = <"La \"Llista de distribució\" és merament informativa i el destinatari principal de l'informe és la persona destinada a actuar en funció de la informació.">
+				>
+				["at0037"] = <
+					text = <"Parcial">
+					description = <"És un resultat parcial (per exemple, inicial, provisional o preliminar): les dades del resultat poden estar incomplets o sense verificar.">
+				>
+				["at0038"] = <
+					text = <"Definitiu">
+					description = <"El resultat de la prova és complet i ha estat verificat per una persona autoritzada.">
+				>
+				["at0040"] = <
+					text = <"Modificat">
+					description = <"El resultat ha estat modificat amb posterioritat a ser definitiu, i està complet i verificat pel patòleg responsable, i les dades del resultat han estat modificades.">
+				>
+				["at0057"] = <
+					text = <"Conclusió">
+					description = <"Descripció narrativa de les conclusions principals.">
+					comment = <"Per exemple: “El patró suggereix una insuficiència renal significativa”. El contingut de la conclusió variarà en funció de la investigació realitzada. Aquesta conclusió ha de coincidir amb el “Diagnòstic de la prova” codificat.">
+				>
+				["at0062"] = <
+					text = <"Identificador de la comanda del sol·licitant">
+					description = <"L'identificador local assignat pel sistema clínic sol·licitant.">
+					comment = <"Equivalent al Dipòsit d'identificador d'ordre d'HL7.">
+				>
+				["at0063"] = <
+					text = <"Identificador de l'ordre del receptor">
+					description = <"L'identificador local assignat a l'ordre de prova per l'emplenador de l'ordre, normalment pel Sistema d'Informació del Laboratori (SIL).">
+					comment = <"L'assignació d'un identificador a una sol·licitud per part del Sistema d'Informació de Laboratori (SIL) permet seguir el progrés de la sol·licitud i relacionar els resultats amb les sol·licituds. També proporciona una referència per ajudar amb les consultes i sol ser equivalent a l'identificador HL7 Filler Order Identifier.">
+				>
+				["at0065"] = <
+					text = <"Detalls de la mostra">
+					description = <"Detalls sobre la substància física analitzada.">
+					comment = <"Si el tipus de mostra està suficientment especificat amb un codi al nom de la prova, aquestes dades addicionals no són necessàries. La vinculació dels resultats a mostres específiques es pot registrar utilitzant elements de \"Identificador de mostra\" tant a CLUSTER.specimen com als diferents arquetips CLUSTER de resultats.">
+				>
+				["at0068"] = <
+					text = <"Identificador intern del laboratori">
+					description = <"Identificador local assignat pel sistema d'informació del laboratori receptor (SIL) per seguir el procés de la prova.">
+					comment = <"Aquest identificador és un número de seguiment intern assignat pel SIL, i no vol ser el nom de la prova.">
+				>
+				["at0073"] = <
+					text = <"Estat general de les proves">
+					description = <"L'estat del resultat de la prova de laboratori en conjunt.">
+					comment = <"Els valors han estat escollits específicament perquè coincideixin amb els de l'informe HL7 FHIR Diagnostic, derivats històricament de la pràctica HL7v2. Poden utilitzar altres codis/termes locals mitjançant el text \"choice\".
+
+Aquest element és de ocurrència múltiple per atendre els casos d'ús en què els estats per a diferents aspectes del resultat s'han dividit en diversos elements.">
+				>
+				["at0074"] = <
+					text = <"Cancel·lat">
+					description = <"El resultat no està disponible perquè la prova no s'ha iniciat o no s'ha completat (de vegades també s'anomena “avortada”).">
+				>
+				["at0075"] = <
+					text = <"Registre de temps de l'estat general de la prova">
+					description = <"La data i/o hora en què es va emetre l'estat general de les proves.">
+				>
+				["at0077"] = <
+					text = <"Especialitat mèdica/clínica">
+					description = <"El servei o la disciplina de diagnòstic responsable del resultat de la prova de laboratori.">
+					comment = <"És una categorització general i no del nom organitzatiu del laboratori. Per exemple: anatomia patològica, immunologia i medicina transfusional, microbiologia mèdica, farmacologia clínica, genètica mèdica, bioquímica mèdica. També es poden utilitzar subcategories o subdisciplines més granulars, com ara endocrinologia, hematologia i serveis d'al·lergologia. Això pot ajudar els clínics a filtrar entre categories de resultats. Sempre que sigui possible, és desitjable codificar amb una terminologia.">
+				>
+				["at0090"] = <
+					text = <"Sol·licitant">
+					description = <"Detalls del metge o organització que sol·licita el resultat de la prova de laboratori.">
+				>
+				["at0094"] = <
+					text = <"Detalls de la sol·licitud de la prova">
+					description = <"Detalls sobre la sol·licitud de la prova.">
+					comment = <"En la majoria de situacions hi ha una sol·licitud de prova i un únic resultat de prova corresponent, però, aquest grup de repetició permet la situació en què hi pot haver diverses sol·licituds de prova notificades utilitzant un únic resultat de prova.
+
+Per exemple: \"un clínic sol·licita glucosa en sang en una petició i urea/electròlits en una segona petició, però el tècnic del laboratori realitza totes dues i el laboratori vol notificar-les juntes\".">
+				>
+				["at0097"] = <
+					text = <"Resultat de la prova">
+					description = <"Resultats de la prova realitzada a la(es) mostra(s).">
+					comment = <"Aquest SLOT pot transportar un analit individual, un grup, panell o bateria de múltiples analits, o una estructura més complexa i específica.">
+				>
+				["at0098"] = <
+					text = <"Dignòstic de la prova">
+					description = <"Paraula única, frase o breu descripció que representa el significat clínic i la importància del resultat de la prova de laboratori.">
+					comment = <"Per exemple: 'Insuficiència hepàtica greu', 'Contaminació per Salmonella'. Es recomana encaridament codificar el diagnòstic amb una terminologia, sempre que sigui possible. Aquest diagnòstic ha d'estar alineat amb la informació registrada a la 'Conclusió'.">
+				>
+				["at0100"] = <
+					text = <"Informació clínica facilitada">
+					description = <"Descripció de la informació clínica disponible al moment de la interpretació dels resultats.">
+					comment = <"Aquest element de dades pot incloure un enllaç a la informació clínica original facilitada a la sol·licitud de prova.">
+				>
+				["at0101"] = <
+					text = <"Comentaris">
+					description = <"Informació addicional sobre el resultat de la prova no recollida a altres camps.">
+				>
+				["at0106"] = <
+					text = <"Nom de la prova original sol·licitada">
+					description = <"Nom de la prova de laboratori original sol·licitada.">
+					comment = <"Aquesta dada s'utilitza quan la prova sol·licitada difereixi de la prova realment realitzada pel laboratori.">
+				>
+				["at0107"] = <
+					text = <"Registrat">
+					description = <"L'existència de la prova està registrada al Sistema d'Informació del Laboratori, però encara no hi ha res disponible.">
+				>
+				["at0110"] = <
+					text = <"Detalls de la prova">
+					description = <"Detalls estructurats sobre el mètode danàlisi, dispositiu o interpretació utilitzat.">
+					comment = <"Per exemple: 'detalls d'ELISA/nefelometria'.">
+				>
+				["at0111"] = <
+					text = <"Prova al punt d'atenció sanitària">
+					description = <"Indica si la prova es va fer directament al punt d'atenció (POCT), en contraposició a un resultat formal d'un laboratori o una altra organització de prestació de serveis.">
+					comment = <"'Verdadero' si la prova es va realitzar directament al punt d'atenció.">
+				>
+				["at0112"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0113"] = <
+					text = <"Factors de confusió">
+					description = <"Qüestions o circumstàncies que influeixen en la interpretació exacta del mesurament o del resultat de la prova.">
+					comment = <"Els \"factors de confusió\" s'han de reservar per a qüestions no controlades/no planificades de l'estat/fisiologia del pacient que puguin afectar la interpretació, per exemple \"exercici recent\" o \"tabaquisme recent\".
+
+Les condicions prèvies conegudes o requerides, com \"dejuni\", s'han d'incloure a l'element \"Condicions de mostreig\" de l'arquetip CLUSTER.specimen. En alguns casos, les condicions prèvies formen part del nom de la prova, per exemple \"Glucosa en sang en dejú\".
+
+Els problemes coneguts de recollida o manipulació de mostres, com \"ús prolongat de torniquet\" o \"mostra hemolitzada\", s'han d'incloure als elements \"Qualitat de la mostra\" de l'arquetip CLUSTER.specimen.
+
+Sempre que sigui possible, és desitjable codificar amb una terminologia.">
+				>
+				["at0114"] = <
+					text = <"Factors de confusió estructurats">
+					description = <"Detalls dels problemes o circumstàncies que influeixen en la interpretació exacta de la mesura o del resultat de l'assaig.">
+					comment = <"Per exemple: Última menstruació normal (LNMP).">
+				>
+				["at0115"] = <
+					text = <"Corregit">
+					description = <"El resultat ha estat modificat amb posterioritat a ser definitiu, i està complet i verificat pel patòleg responsable. Es tracta d'una subcategoria de \"modificat\".">
+				>
+				["at0116"] = <
+					text = <"Afegit per error">
+					description = <"El resultat de la prova ha estat retirat després de la publicació final anterior.">
+				>
+				["at0117"] = <
+					text = <"Ampliació">
+					description = <"Informació addicional necessària per captar el contingut local o per alinear-se amb altres models/formalismes de referència.">
+					comment = <"Per exemple: requisits locals d'informació o metadades addicionals per alinear-se amb els equivalents de FHIR o CIMI.">
+				>
+				["at0118"] = <
+					text = <"Representació multimèdia">
+					description = <"Imatge digital, vídeo o diagrama que representa el resultat de la prova.">
+					comment = <"Es permeten múltiples formats, però han de representar continguts clínics equivalents.">
+				>
+				["at0119"] = <
+					text = <"Annex">
+					description = <"Després de ser definitiu, l'informe s'ha modificat afegint-hi continguts nous. No s'ha modificat el contingut existent. Es tracta d'una subcategoria de \"modificat\".">
+				>
+				["at0120"] = <
+					text = <"Preliminar">
+					description = <"Es disposen de resultats preliminars verificats, però no tots els resultats són definitius. Es tracta d'una subcategoria de “Parcial”.">
+				>
+				["at0121"] = <
+					text = <"Mètode de prova">
+					description = <"Descripció sobre el mètode utilitzat per fer la prova.">
+					comment = <"Sempre que sigui possible, és desitjable codificar amb una terminologia.">
+				>
+				["at0122"] = <
+					text = <"Diagnòstic de prova estructurat">
+					description = <"Un diagnòstic estructurat o complex per a la prova de laboratori.">
+					comment = <"Per exemple: Diagnòstics anatomopatològics que consten de diversos eixos diferents, com ara la morfologia, l'etiologia i la funció.">
+				>
+			>
+		>
+		["fi"] = <
+			items = <
+				["at0000"] = <
+					text = <"Laboratoriokokeen tulos">
+					description = <"*The result, including findings and the laboratory's interpretation, of an investigation performed on specimens collected from an individual or related to that individual.(en)">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Mikä tahansa tapahtuma">
+					description = <"*Default, unspecified point in time or interval event which may be explicitly defined in a template or at run-time.(en)">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0005"] = <
+					text = <"Tutkimusnimi">
+					description = <"*Name of the laboratory investigation performed on the specimen(s).(en)">
+					comment = <"*A test result may be for a single analyte, or a group of items, including panel tests. It is strongly recommended that 'Test name' be coded with a terminology, for example LOINC or SNOMED CT. For example: 'Glucose', 'Urea and Electrolytes', 'Swab', 'Cortisol (am)', 'Potassium in perspiration' or 'Melanoma histopathology'. The name may sometimes include specimen type and patient state, for example 'Fasting blood glucose' or include other information, as 'Potassium (PNA blood gas)'.(en)">
+				>
+				["at0017"] = <
+					text = <"*Receiving laboratory(en)">
+					description = <"*Details of the laboratory which received the request and has overall responsibility to manage reporting of the test, even if other labs perform specific aspects.(en)">
+					comment = <"*This slot is intended to carry details of the laboratory which received the request and has overall responsibility to manage reporting of the test, even if other labs perform specific aspects.
+
+The receiving laboratory may either perform the test or refer it to another laboratory. Where a different laboratory is responsible for performing the testing on specific analytes, it would be expected that these details would be carried in the 'Analyte result detail' SLOT within the CLUSTER.laboratory_test_analyte archetype.
+
+(en)">
+				>
+				["at0035"] = <
+					text = <"*Distribution list(en)">
+					description = <"*Details of additional clinicians or organisations who require a copy of the test result.(en)">
+					comment = <"*The 'Distribution list' is for information-only, and that the primary recipient of the report is the person intended to act on the information.(en)">
+				>
+				["at0037"] = <
+					text = <"*Partial(en)">
+					description = <"*This is a partial (e.g. initial, interim or preliminary) Test Result: data in the Test Result may be incomplete or unverified.(en)">
+				>
+				["at0038"] = <
+					text = <"*Final(en)">
+					description = <"*The Test result is complete and verified by an authorised person.(en)">
+				>
+				["at0040"] = <
+					text = <"*Amended(en)">
+					description = <"*The result has been modified subsequent to being Final, and is complete and verified by the responsible pathologist, and result data has been changed.(en)">
+				>
+				["at0057"] = <
+					text = <"*Conclusion(en)">
+					description = <"*Narrative description of the key findings.(en)">
+					comment = <"*For example: 'Pattern suggests significant renal impairment'. The content of the conclusion will vary, depending on the investigation performed. This conclusion should be aligned with the coded 'Test diagnosis'.(en)">
+				>
+				["at0062"] = <
+					text = <"*Requester order identifier(en)">
+					description = <"*The local identifier assigned by the requesting clinical system.(en)">
+					comment = <"*Equivalent to the HL7 Placer Order Identifier.(en)">
+				>
+				["at0063"] = <
+					text = <"*Receiver order identifier(en)">
+					description = <"*The local identifier assigned to the test order by the order filler, usually by the Laboratory Information System (LIS).(en)">
+					comment = <"*Assigning an identifier to a request by the Laboratory lnformation System (LIS) enables tracking progress of the request and enables linking results to requests. It also provides a reference to assist with enquiries and it is usually equivalent to the HL7 Filler Order Identifier.(en)">
+				>
+				["at0065"] = <
+					text = <"*Specimen detail(en)">
+					description = <"*Details about the physical substance that has been analysed.(en)">
+					comment = <"*If the specimen type is sufficiently specified with a code in the Test name, then this additional data is not required. Linking results to specific specimens may be recorded using 'Specimen identifier' elements in both the CLUSTER.specimen and the various results CLUSTER archetypes.(en)">
+				>
+				["at0068"] = <
+					text = <"*Laboratory internal identifier(en)">
+					description = <"*A local identifier assigned by the receiving Laboratory Information System (LIS) to track the test process.(en)">
+					comment = <"*This identifier is an internal tracking number assigned by the LIS, and it not intended to be the name of the test.(en)">
+				>
+				["at0073"] = <
+					text = <"*Overall test status(en)">
+					description = <"*The status of the laboratory test result as a whole.(en)">
+					comment = <"*The values have been specifically chosen to match those in the HL7 FHIR Diagnostic report, historically derived from HL7v2 practice. Other local codes/terms can be used via the Text 'choice'.
+
+This element is multiple occurrence to cater for the use cases where statuses for different aspects of the result have been split into several elements.(en)">
+				>
+				["at0074"] = <
+					text = <"*Cancelled(en)">
+					description = <"*The result is unavailable because the test was not started or not completed (also sometimes called 'aborted').(en)">
+				>
+				["at0075"] = <
+					text = <"*Overall test status timestamp(en)">
+					description = <"*The date and/or time that ‘Overall test status’ was issued.(en)">
+				>
+				["at0077"] = <
+					text = <"*Diagnostic service category(en)">
+					description = <"*The diagnostic service or discipline that is responsible for the laboratory test result.(en)">
+					comment = <"*This is intended to be a general categorisation and not to capture the organisational name of the laboratory. For example: anatomical pathology, immunology and transfusion medicine, medical microbiology, clinical pharmacology, medical genetics, medical biochemistry. Alternatively more granular sub categories or sub disciplines, such as endocrinology, haematology, and allergology services, may be used. This may assist clinicians in filtering between categories of results. Coding with a terminology is desirable, where possible.(en)">
+				>
+				["at0090"] = <
+					text = <"*Requester(en)">
+					description = <"*Details of the clinician or organisation requesting the laboratory test result.(en)">
+				>
+				["at0094"] = <
+					text = <"*Test request details(en)">
+					description = <"*Details about the test request.(en)">
+					comment = <"*In most situations there is one test request and a single corresponding test result, however this repeating cluster allows for the situation where there may be multiple test requests reported using a single test result.
+
+As an example: 'a clinician asks for blood glucose in one request and Urea/electrolytes in a second request, but the lab analyser does both and the lab wishes to report these together'.(en)">
+				>
+				["at0097"] = <
+					text = <"Tutkimustulos">
+					description = <"*Results of the test performed on the specimen(s).(en)">
+					comment = <"*This SLOT may carry an individual analyte, a group, panel or battery of multiple analytes, or a more complex and specific structure.(en)">
+				>
+				["at0098"] = <
+					text = <"*Test diagnosis(en)">
+					description = <"*Single word, phrase or brief description that represents the clinical meaning and significance of the laboratory test result.(en)">
+					comment = <"*For example: 'Severe hepatic impairment', 'Salmonella contamination'. Coding of the diagnosis with a terminology is strongly recommended, where possible. This diagnosis should be aligned with the narrative in the 'Conclusion'.(en)">
+				>
+				["at0100"] = <
+					text = <"*Clinical information provided(en)">
+					description = <"*Description of clinical information available at the time of interpretation of results.(en)">
+					comment = <"*This data element may include a link to the original clinical information provided in the test request.(en)">
+				>
+				["at0101"] = <
+					text = <"Kommentti">
+					description = <"*Additional narrative about the test result not captured in other fields.(en)">
+				>
+				["at0106"] = <
+					text = <"*Original test requested name(en)">
+					description = <"*Name of the original laboratory test requested.(en)">
+					comment = <"*This data element is to be used when the test requested differs from the test actually performed by the laboratory.(en)">
+				>
+				["at0107"] = <
+					text = <"*Registered(en)">
+					description = <"*The existence of the test is registered in the Laboratory Information System, but there is nothing yet available.(en)">
+				>
+				["at0110"] = <
+					text = <"*Testing details(en)">
+					description = <"*Structured details about the method of analysis, device or interpretation used.(en)">
+					comment = <"*For example: 'details of ELISA/nephelometry'.(en)">
+				>
+				["at0111"] = <
+					text = <"*Point-of-care test(en)">
+					description = <"*This indicates whether the test was performed directly at Point-of-Care (POCT) as opposed to a formal result from a laboratory or other service delivery organisation.(en)">
+					comment = <"*True if the test was performed directly at Point-of-Care (POCT).(en)">
+				>
+				["at0112"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0113"] = <
+					text = <"Haittaavat tekijät">
+					description = <"*Issues or circumstances that impact on the accurate interpretation of the measurement or test result.(en)">
+					comment = <"*'Confounding factors' should be reserved for uncontrolled/unplanned issues of patient state/physiology that might affect interpretation, for example 'recent exercise' or 'recent tobacco smoking'.
+
+Known or required preconditions, such as 'fasting' should be carried in the 'Sampling conditions' element within the CLUSTER.specimen archetype . In some cases preconditions are captured as part of the test name, for example 'Fasting blood glucose'.
+
+Known issues with specimen collection or handling, such as 'prolonged use of tourniquet' or 'sample haemolysed', should be carried in the 'Specimen quality' elements within CLUSTER.specimen archetype.
+
+Coding with a terminology is desirable, where possible.(en)">
+				>
+				["at0114"] = <
+					text = <"*Structured confounding factors(en)">
+					description = <"*Details of issues or circumstances that impact on the accurate interpretation of the measurement or test result.(en)">
+					comment = <"*For example: Last Normal Menstrual Period (LNMP).(en)">
+				>
+				["at0115"] = <
+					text = <"*Corrected(en)">
+					description = <"*The result has been modified subsequent to being Final, and is complete and verified by the responsible pathologist. This is a sub-category of 'Amended'.(en)">
+				>
+				["at0116"] = <
+					text = <"*Entered in error(en)">
+					description = <"*The Test Result has been withdrawn following previous Final release.(en)">
+				>
+				["at0117"] = <
+					text = <"*Extension(en)">
+					description = <"*Additional information required to capture local content or to align with other reference models/formalisms.(en)">
+					comment = <"*For example: local information requirements or additional metadata to align with FHIR or CIMI equivalents.(en)">
+				>
+				["at0118"] = <
+					text = <"*Multimedia representation(en)">
+					description = <"*Digital image, video or diagram representing the test result.(en)">
+					comment = <"*Multiple formats are allowed but they should represent equivalent clinical content.(en)">
+				>
+				["at0119"] = <
+					text = <"*Appended(en)">
+					description = <"*Subsequent to being final, the report has been modified by adding new content. The existing content is unchanged. This is a sub-category of 'Amended'.(en)">
+				>
+				["at0120"] = <
+					text = <"*Preliminary(en)">
+					description = <"*Verified early results are available, but not all results are final. This is a sub-category of 'Partial'.(en)">
+				>
+				["at0121"] = <
+					text = <"*Test method(en)">
+					description = <"*Description about the method used to perform the test.(en)">
+					comment = <"*Coding with a terminology is desirable, where possible.(en)">
+				>
+				["at0122"] = <
+					text = <"*Structured test diagnosis(en)">
+					description = <"*A structured or complex diagnosis for the laboratory test.(en)">
+					comment = <"*For example: Anatomical pathology diagnoses consisting of several different axes such as morphology, etiology and function.(en)">
+				>
+			>
+		>
+	>

--- a/input/fsh/Examples/LabResult.fsh
+++ b/input/fsh/Examples/LabResult.fsh
@@ -1,0 +1,110 @@
+Alias: $SCT = http://snomed.info/sct
+Alias: $UCUM = http://unitsofmeasure.org
+Alias: $ObsCat = http://terminology.hl7.org/CodeSystem/observation-category
+Alias: $analyte-archetype = https://specifications.openehr.org/releases/CKM/latest/CLUSTER.laboratory_test_analyte.v1
+
+Profile: LabResult
+Parent: Observation
+Id: LabResult
+Title: "Laboratory Analyte Result"
+Description: """
+FHIR Observation profile representing a single laboratory analyte result.
+
+Designed to be semantically interoperable with the openEHR
+`openEHR-EHR-CLUSTER.laboratory_test_analyte.v1` archetype. Every constrained
+element below carries an explicit `mapping` entry pointing at the equivalent
+archetype node path. Four archetype elements have no idiomatic FHIR equivalent
+on Observation and are documented as additional mapping rows (with
+"(not represented)"): `at0027` (Analyte result sequence), `at0014` (Analyte
+result detail), `at0006` (Result status time), `at0032` (Accredited).
+"""
+
+* ^mapping[+].identity = "openehr-analyte"
+* ^mapping[=].uri = $analyte-archetype
+* ^mapping[=].name = "openEHR Laboratory analyte result (v1)"
+* ^mapping[=].comment = "Element-by-element mapping to openEHR-EHR-CLUSTER.laboratory_test_analyte.v1. Paths are relative to the archetype root CLUSTER[at0000]."
+
+// Archetype elements not represented on Observation itself; documented here for completeness.
+* . ^mapping[+].identity = "openehr-analyte"
+* . ^mapping[=].map = "items[at0027]/value (not represented)"
+* . ^mapping[=].comment = "openEHR 'Analyte result sequence' (DV_COUNT) records the position of this analyte within a multi-analyte report (e.g. HL7 v2 OBX-1). When a panel is represented as multiple FHIR Observation resources, ordering is conveyed by the position in DiagnosticReport.result rather than on the Observation itself. Add an extension if you need to preserve the integer on the individual resource."
+* . ^mapping[+].identity = "openehr-analyte"
+* . ^mapping[=].map = "items[at0014] (not represented)"
+* . ^mapping[=].comment = "openEHR 'Analyte result detail' is an open CLUSTER slot used to plug in additional structured detail (e.g. quality flags, microbiology susceptibility, derived calculations). FHIR-side this would land in Observation.component for sub-measurements, Observation.hasMember / derivedFrom for related Observations, or an extension for ad-hoc data."
+
+* category 1..* MS
+* category ^slicing.discriminator.type = #pattern
+* category ^slicing.discriminator.path = "$this"
+* category ^slicing.rules = #open
+* category contains laboratory 1..1 MS
+* category[laboratory] = $ObsCat#laboratory "Laboratory"
+* category ^mapping[+].identity = "openehr-analyte"
+* category ^mapping[=].map = "(implicit)"
+* category ^mapping[=].comment = "No equivalent element on the openEHR archetype — the laboratory context is implicit in the archetype's identity (openEHR-EHR-CLUSTER.laboratory_test_analyte). FHIR makes this explicit on Observation.category and we therefore fix it to 'laboratory'."
+
+* status 1..1 MS
+* status ^mapping[+].identity = "openehr-analyte"
+* status ^mapping[=].map = "items[at0005]/value"
+* status ^mapping[=].comment = "openEHR DV_CODED_TEXT (registered|partial|preliminary|final|corrected|amended|appended|entered-in-error|cancelled) → FHIR Observation.status. 'partial' and 'appended' have no exact FHIR code and collapse to 'preliminary' and 'amended' respectively."
+* status ^mapping[+].identity = "openehr-analyte"
+* status ^mapping[=].map = "items[at0006]/value (not represented)"
+* status ^mapping[=].comment = "openEHR 'Result status time' records *when* the status above transitioned to its current value. FHIR Observation has no analogous timestamp field — the audit trail of status changes is normally carried on a Provenance resource pointing at the Observation, with Provenance.recorded holding this value."
+
+* code 1..1 MS
+* code ^mapping[+].identity = "openehr-analyte"
+* code ^mapping[=].map = "items[at0024]/value"
+* code ^mapping[=].comment = "openEHR DV_TEXT (Analyte name) → FHIR Observation.code (CodeableConcept). FHIR encourages a coded value (LOINC or SNOMED CT); the archetype permits free text."
+
+* value[x] MS
+* value[x] ^mapping[+].identity = "openehr-analyte"
+* value[x] ^mapping[=].map = "items[at0001]/value"
+* value[x] ^mapping[=].comment = "openEHR 'Analyte result' is type-open (DV_QUANTITY, DV_CODED_TEXT, DV_TEXT, DV_BOOLEAN, DV_ORDINAL, …). FHIR value[x] expresses the same flexibility via its multiple alternative types."
+
+* effectiveDateTime 0..1 MS
+* effectiveDateTime ^mapping[+].identity = "openehr-analyte"
+* effectiveDateTime ^mapping[=].map = "items[at0031]/value"
+* effectiveDateTime ^mapping[=].comment = "openEHR 'Analysis performed time' (DV_DATE_TIME) → FHIR Observation.effective[x]: when the analysis was physically performed."
+
+* issued 0..1 MS
+* issued ^mapping[+].identity = "openehr-analyte"
+* issued ^mapping[=].map = "items[at0025]/value"
+* issued ^mapping[=].comment = "openEHR 'Validation time' (DV_DATE_TIME) → FHIR Observation.issued: when the validated result was released."
+
+* method 0..1
+* method ^mapping[+].identity = "openehr-analyte"
+* method ^mapping[=].map = "items[at0028]/value"
+* method ^mapping[=].comment = "openEHR 'Test method' → FHIR Observation.method (CodeableConcept)."
+* method ^mapping[+].identity = "openehr-analyte"
+* method ^mapping[=].map = "items[at0032]/value (not represented)"
+* method ^mapping[=].comment = "openEHR 'Accredited' (DV_BOOLEAN / DV_TEXT) flags whether the analytical method holds an accreditation (e.g. ISO 15189). FHIR Observation has no native field for this quality-assurance flag; would need an extension on Observation.method if required."
+
+* specimen 0..1
+* specimen ^mapping[+].identity = "openehr-analyte"
+* specimen ^mapping[=].map = "items[at0026]/value"
+* specimen ^mapping[=].comment = "openEHR 'Specimen' (DV_IDENTIFIER / DV_URI / DV_TEXT) → FHIR Observation.specimen (Reference to Specimen). FHIR moves identification into a separate Specimen resource."
+
+* referenceRange 0..*
+* referenceRange ^mapping[+].identity = "openehr-analyte"
+* referenceRange ^mapping[=].map = "items[at0004]/value"
+* referenceRange ^mapping[=].comment = "openEHR 'Reference range guidance' (DV_TEXT) lands in Observation.referenceRange.text. Numeric low/high typically come from the result DV_QUANTITY's normalRange, which is not modelled at this archetype level."
+
+* note 0..*
+* note ^mapping[+].identity = "openehr-analyte"
+* note ^mapping[=].map = "items[at0003]/value"
+* note ^mapping[=].comment = "openEHR 'Comment' (DV_TEXT, 0..*) → FHIR Observation.note (Annotation, 0..*). The DV_TEXT value lands in Annotation.text."
+
+
+Instance: example-psa-result
+InstanceOf: LabResult
+Usage: #example
+Title: "Example PSA Result (4.2 ng/mL)"
+Description: "Sample LabResult instance demonstrating archetype-compatible population of every mapped element."
+* status = #final
+* category[laboratory] = $ObsCat#laboratory "Laboratory"
+* code = $SCT#63476009 "Prostate specific antigen measurement"
+* effectiveDateTime = "2026-05-16T08:23:00+02:00"
+* issued = "2026-05-16T11:05:00+02:00"
+* valueQuantity = 4.2 $UCUM#ng/mL "ng/mL"
+* method = $SCT#726449005 "Immunoassay technique"
+* referenceRange.text = "<4.0 ng/mL for males over 50"
+* note.text = "Sample slightly haemolysed; result interpreted with caution."


### PR DESCRIPTION
## Summary
- Adds the canonical openEHR lab-measurement archetypes (laboratory_test_result.v1 OBSERVATION + laboratory_test_panel.v0 + laboratory_test_analyte.v1 CLUSTERs) to \`input/archetypes/\`, with \`rm_release=1.1.0\` patched into each header so the IG Publisher's ADL 1.4 parser can bind the openEHR Reference Model.
- Local override of \`ig-tiro-template/layouts/layout-profile.html\` that re-introduces the \`ADL\` and \`openEHR View\` tabs on archetype-derived profile pages (gated on \`site.data.structuredefinitions["<id>"].adl\`, so only openEHR-derived profiles get them). Our base \`fhir.base.template\` doesn't ship those tabs; \`fhir2.base.template\` does but switching base requires multilingual scaffolding we don't have.
- Adds a FHIR \`LabResult\` Observation profile semantically interoperable with the \`laboratory_test_analyte.v1\` archetype, plus a worked example (\`example-psa-result\`). All 13 archetype elements are documented in the Mapping tab — 9 mapped, 1 implicit (category fixed to \`laboratory\`), 4 marked \`(not represented)\` with rationale and FHIR fallback advice.

## Test plan
- [ ] \`./_genonce.sh\` succeeds (exit 0)
- [ ] \`output/StructureDefinition-openEHR-EHR-OBSERVATION.laboratory-test-result.v1.html\` exposes \`tabs-adl\` and \`tabs-openehr\`
- [ ] \`output/StructureDefinition-LabResult-mappings.html\` shows all 14 archetype mapping rows
- [ ] \`output/Observation-example-psa-result.html\` validates against the profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)