### PR TITLE
Land cardiac follow-up commits that missed master (24h-HR LOINC panel, vital-signs profile, SNOMED panel groupers)

### DIFF
--- a/input/fsh/Examples/CardiacMeasurement.fsh
+++ b/input/fsh/Examples/CardiacMeasurement.fsh
@@ -44,16 +44,14 @@ SNOMED CT code as soon as a suitable concept becomes available.
 * #pause-count "Sinus pause count"
 * #longest-pause "Longest sinus pause duration"
 
-// Ventricular tachycardia run statistics — no LOINC equivalents. PVC count
+// Ventricular tachycardia longest run — no LOINC equivalent. PVC count
 // uses LOINC#76126-2 directly and is not duplicated here.
-* #vt-run-count "Ventricular tachycardia run count"
 * #vt-longest-run "Ventricular tachycardia longest run length"
 
-// Supraventricular tachycardia run statistics — no LOINC equivalents.
-// SVEB count uses LOINC#8615-7 "Premature atrial contractions" and is
-// not duplicated here.
+// Supraventricular tachycardia run count — no LOINC equivalent. SVEB
+// count uses LOINC#8615-7 "Premature atrial contractions" and is not
+// duplicated here.
 * #svt-run-count "Supraventricular tachycardia run count"
-* #svt-longest-run "Supraventricular tachycardia longest run length"
 
 
 Profile: CardiacMeasurement
@@ -126,6 +124,7 @@ Usage: #example
 Title: "Example: ECG heart rate (72 bpm)"
 Description: "Resting heart rate from a 12-lead ECG."
 * status = #final
+* subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#8867-4 "Heart rate"
 * valueQuantity = 72 $UCUM#/min "beats per minute"
@@ -139,6 +138,7 @@ Usage: #example
 Title: "Example: ECG PR interval (160 ms)"
 Description: "PR interval from a 12-lead ECG."
 * status = #final
+* subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#8625-6 "P-R interval"
 * valueQuantity = 160 $UCUM#ms "ms"
@@ -152,6 +152,7 @@ Usage: #example
 Title: "Example: ECG QRS duration (92 ms)"
 Description: "QRS complex duration from a 12-lead ECG."
 * status = #final
+* subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#8633-0 "QRS duration"
 * valueQuantity = 92 $UCUM#ms "ms"
@@ -165,6 +166,7 @@ Usage: #example
 Title: "Example: ECG QT interval (380 ms)"
 Description: "QT interval from a 12-lead ECG (uncorrected)."
 * status = #final
+* subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#8634-8 "Q-T interval"
 * valueQuantity = 380 $UCUM#ms "ms"
@@ -178,6 +180,7 @@ Usage: #example
 Title: "Example: ECG QTc Bazett (415 ms)"
 Description: "QT interval corrected by Bazett's formula."
 * status = #final
+* subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#76635-2 "QTc interval by Bazett formula"
 * valueQuantity = 415 $UCUM#ms "ms"
@@ -191,6 +194,7 @@ Usage: #example
 Title: "Example: ECG QTc Fridericia (405 ms)"
 Description: "QT interval corrected by Fridericia's formula."
 * status = #final
+* subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#76634-5 "QTc interval by Fridericia formula"
 * valueQuantity = 405 $UCUM#ms "ms"
@@ -204,6 +208,7 @@ Usage: #example
 Title: "Example: ECG P wave duration (98 ms)"
 Description: "P wave duration from a 12-lead ECG."
 * status = #final
+* subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#8632-2 "P wave duration"
 * valueQuantity = 98 $UCUM#ms "ms"
@@ -224,6 +229,7 @@ Note: issue #11's table cites `8601-0`, but the LOINC concept for
 by HL7 US Core). `8601-0` does not exist.
 """
 * status = #final
+* subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#8601-7 "EKG impression"
 * valueCodeableConcept = $SCT#426177001 "Normal sinus rhythm"
@@ -249,6 +255,7 @@ codes use the verified LOINC 24h-HR concepts (min `8883-1`, mean
 `41924-2`, max `8873-2`).
 """
 * status = #final
+* subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#43149-4 "Heart rate device panel"
 * code.text = "Holter 24h heart rate summary (mean / max / min)"
@@ -275,6 +282,7 @@ metric is carried on a component. None of the metrics has a LOINC
 equivalent today, so component codes come from `TiroCardiacMetric`.
 """
 * status = #final
+* subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $SCT#49436004 "Atrial fibrillation"
 * method = $SCT#86184003 "Electrocardiographic ambulatory monitoring"
@@ -283,9 +291,9 @@ equivalent today, so component codes come from `TiroCardiacMetric`.
 * component[0].code = TiroCardiacMetric#afib-burden "Atrial fibrillation burden"
 * component[=].valueQuantity = 12.5 $UCUM#% "%"
 * component[+].code = TiroCardiacMetric#afib-episode-count "Atrial fibrillation episode count"
-* component[=].valueQuantity = 7 $UCUM#1 "{count}"
+* component[=].valueQuantity = 7 $UCUM#1 "{episodes}"
 * component[+].code = TiroCardiacMetric#afib-longest-episode "Atrial fibrillation longest episode duration"
-* component[=].valueQuantity = 412 $UCUM#s "s"
+* component[=].valueQuantity = 23 $UCUM#min "min"
 
 
 Instance: example-holter-pause
@@ -298,13 +306,14 @@ longest pause duration. Parent code is a Tiro panel grouper (LOINC has
 no pause panel); components use Tiro local codes.
 """
 * status = #final
+* subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = TiroCardiacMetric#pause-panel "Sinus pause Holter panel"
 * method = $SCT#86184003 "Electrocardiographic ambulatory monitoring"
 * effectivePeriod.start = "2026-05-10T08:00:00+02:00"
 * effectivePeriod.end   = "2026-05-11T08:00:00+02:00"
 * component[0].code = TiroCardiacMetric#pause-count "Sinus pause count"
-* component[=].valueQuantity = 3 $UCUM#1 "{count}"
+* component[=].valueQuantity = 3 $UCUM#1 "{events}"
 * component[+].code = TiroCardiacMetric#longest-pause "Longest sinus pause duration"
 * component[=].valueQuantity = 2.8 $UCUM#s "s"
 
@@ -321,6 +330,7 @@ the panel grouper have no LOINC equivalents, so those come from
 `TiroCardiacMetric`.
 """
 * status = #final
+* subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = TiroCardiacMetric#ventricular-ectopy-panel "Ventricular ectopy Holter panel"
 * method = $SCT#86184003 "Electrocardiographic ambulatory monitoring"
@@ -328,8 +338,6 @@ the panel grouper have no LOINC equivalents, so those come from
 * effectivePeriod.end   = "2026-05-11T08:00:00+02:00"
 * component[0].code = $LOINC#76126-2 "Premature ventricular contractions [#]"
 * component[=].valueQuantity = 248 $UCUM#1 "{beats}"
-* component[+].code = TiroCardiacMetric#vt-run-count "Ventricular tachycardia run count"
-* component[=].valueQuantity = 2 $UCUM#1 "{count}"
 * component[+].code = TiroCardiacMetric#vt-longest-run "Ventricular tachycardia longest run length"
 * component[=].valueQuantity = 5 $UCUM#1 "{beats}"
 
@@ -347,6 +355,7 @@ statistics and the panel grouper have no LOINC equivalents and come
 from `TiroCardiacMetric`.
 """
 * status = #final
+* subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = TiroCardiacMetric#supraventricular-ectopy-panel "Supraventricular ectopy Holter panel"
 * method = $SCT#86184003 "Electrocardiographic ambulatory monitoring"
@@ -355,9 +364,7 @@ from `TiroCardiacMetric`.
 * component[0].code = $LOINC#8615-7 "Premature atrial contractions"
 * component[=].valueQuantity = 94 $UCUM#1 "{beats}"
 * component[+].code = TiroCardiacMetric#svt-run-count "Supraventricular tachycardia run count"
-* component[=].valueQuantity = 4 $UCUM#1 "{count}"
-* component[+].code = TiroCardiacMetric#svt-longest-run "Supraventricular tachycardia longest run length"
-* component[=].valueQuantity = 8 $UCUM#1 "{beats}"
+* component[=].valueQuantity = 4 $UCUM#1 "{events}"
 
 
 Instance: example-holter-qtc
@@ -366,9 +373,87 @@ Usage: #example
 Title: "Example: Holter QTc (420 ms)"
 Description: "Corrected QT interval derived from a 24h Holter recording."
 * status = #final
+* subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#8636-3 "Q-T interval corrected"
 * valueQuantity = 420 $UCUM#ms "ms"
 * method = $SCT#86184003 "Electrocardiographic ambulatory monitoring"
 * effectivePeriod.start = "2026-05-10T08:00:00+02:00"
 * effectivePeriod.end   = "2026-05-11T08:00:00+02:00"
+
+
+// ─────────────────────────────────────────────────────────────────────
+// AZMM test patient — referenced by every example in this file.
+// Per Joeri Christiaens (AZMM, mail 2026-05-19): instead of creating
+// per-recording Patient resources, point Holter/ECG Observations at one
+// of the two existing AZMM test patients.
+// ─────────────────────────────────────────────────────────────────────
+
+Instance: AZMMTestPatient1
+InstanceOf: Patient
+Usage: #example
+Title: "AZMM test patient 1 (lS8whV3.114131)"
+Description: "Existing AZMM test patient already used in AZMM ↔ Tiro.health interop testing. The id mirrors the literal id used on AZMM's FHIR endpoint so Observations created here resolve there."
+* identifier.system = "https://fhir-ns.mijnziekenhuis.be/id/patient/azmm"
+* identifier.value = "lS8whV3.114131"
+
+
+// ─────────────────────────────────────────────────────────────────────
+// CardiacVitalSigns profile — for the real-time / flowsheet feed case
+// (avg HR from a Holter or telemetry recording landing on a vital-signs
+// flowsheet). Per Joeri Christiaens (mail 2026-05-19), Holter
+// Observations are not always category=procedure: a hospital may also
+// emit recurring averages that belong in vital-signs.
+//
+// Profile is a sibling, not a child, of CardiacMeasurement because the
+// fixed `category` value differs.
+// ─────────────────────────────────────────────────────────────────────
+
+Profile: CardiacVitalSigns
+Parent: Observation
+Id: CardiacVitalSigns
+Title: "Cardiac Vital Signs"
+Description: """
+FHIR Observation profile for cardiac measurements that flow into a
+vital-signs / flowsheet stream rather than into a final cardiology
+report. Typical use case: a Holter device emits a rolling average heart
+rate every hour and those values are written as discrete vital-signs
+Observations.
+
+`category` is fixed to `vital-signs` (the HL7 observation-category
+code) — this is the distinguishing constraint from `CardiacMeasurement`,
+which fixes `category` to `procedure`. Use `CardiacMeasurement` for the
+cardiologist's final report and panel-style summaries; use this profile
+for individual real-time measurements.
+"""
+
+* category 1..* MS
+* category ^slicing.discriminator.type = #pattern
+* category ^slicing.discriminator.path = "$this"
+* category ^slicing.rules = #open
+* category contains vitalSigns 1..1 MS
+* category[vitalSigns] = $ObsCat#vital-signs "Vital Signs"
+
+* status 1..1 MS
+* code 1..1 MS
+* subject 1..1 MS
+* effective[x] 1..1 MS
+* effective[x] only dateTime or Period
+
+
+Instance: example-holter-heart-rate-vitals
+InstanceOf: CardiacVitalSigns
+Usage: #example
+Title: "Example: Holter rolling average heart rate (78 bpm)"
+Description: """
+A single rolling-window average heart rate from a Holter monitor
+landing on the patient's flowsheet. Equivalent to Laurent Ganton's
+`CreateObservationEntry(Holter,…)` path (Fhir_Holter.txt l.5-9), which
+already emits `category = vital-signs`.
+"""
+* status = #final
+* subject = Reference(AZMMTestPatient1)
+* category[vitalSigns] = $ObsCat#vital-signs "Vital Signs"
+* code = $LOINC#8867-4 "Heart rate"
+* valueQuantity = 78 $UCUM#/min "beats per minute"
+* effectiveDateTime = "2026-05-10T09:00:00+02:00"

--- a/input/fsh/Examples/CardiacMeasurement.fsh
+++ b/input/fsh/Examples/CardiacMeasurement.fsh
@@ -27,13 +27,14 @@ SNOMED CT code as soon as a suitable concept becomes available.
 * ^experimental = false
 * ^caseSensitive = true
 
-// Panel grouper codes (used on parent Observation.code) — LOINC has no
-// equivalent Holter summary panels for these. (24h heart rate uses the
-// real LOINC panel `43149-4` "Heart rate device panel" with a clarifying
-// `code.text`; no Tiro code needed there.)
-* #pause-panel "Sinus pause Holter panel"
-* #ventricular-ectopy-panel "Ventricular ectopy Holter panel"
-* #supraventricular-ectopy-panel "Supraventricular ectopy Holter panel"
+// All Holter panel grouper codes now use SNOMED CT finding codes
+// directly on `Observation.code`:
+//   - AFib panel             → SCT#49436004  "Atrial fibrillation"
+//   - Sinus pause panel      → SCT#5609005   "Sinus arrest"
+//   - Ventricular ectopy     → SCT#17338001  "Ventricular premature beats"
+//   - Supraventricular ectopy→ SCT#63593006  "Supraventricular premature beats"
+//   - 24h heart rate         → LOINC#43149-4 "Heart rate device panel" (+ code.text)
+// No Tiro panel grouper codes are needed.
 
 // AFib component metrics — no LOINC equivalents.
 * #afib-burden "Atrial fibrillation burden (% of recording in AF)"
@@ -308,7 +309,8 @@ no pause panel); components use Tiro local codes.
 * status = #final
 * subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
-* code = TiroCardiacMetric#pause-panel "Sinus pause Holter panel"
+* code = $SCT#5609005 "Sinus arrest"
+* code.text = "Sinus pause / arrest panel (pause count + longest pause)"
 * method = $SCT#86184003 "Electrocardiographic ambulatory monitoring"
 * effectivePeriod.start = "2026-05-10T08:00:00+02:00"
 * effectivePeriod.end   = "2026-05-11T08:00:00+02:00"
@@ -332,7 +334,8 @@ the panel grouper have no LOINC equivalents, so those come from
 * status = #final
 * subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
-* code = TiroCardiacMetric#ventricular-ectopy-panel "Ventricular ectopy Holter panel"
+* code = $SCT#17338001 "Ventricular premature beats"
+* code.text = "Ventricular ectopy panel (PVC count + VT longest run)"
 * method = $SCT#86184003 "Electrocardiographic ambulatory monitoring"
 * effectivePeriod.start = "2026-05-10T08:00:00+02:00"
 * effectivePeriod.end   = "2026-05-11T08:00:00+02:00"
@@ -357,7 +360,8 @@ from `TiroCardiacMetric`.
 * status = #final
 * subject = Reference(AZMMTestPatient1)
 * category[procedure] = $ObsCat#procedure "Procedure"
-* code = TiroCardiacMetric#supraventricular-ectopy-panel "Supraventricular ectopy Holter panel"
+* code = $SCT#63593006 "Supraventricular premature beats"
+* code.text = "Supraventricular ectopy panel (PAC count + SVT run count)"
 * method = $SCT#86184003 "Electrocardiographic ambulatory monitoring"
 * effectivePeriod.start = "2026-05-10T08:00:00+02:00"
 * effectivePeriod.end   = "2026-05-11T08:00:00+02:00"

--- a/input/fsh/Examples/CardiacMeasurement.fsh
+++ b/input/fsh/Examples/CardiacMeasurement.fsh
@@ -28,11 +28,12 @@ SNOMED CT code as soon as a suitable concept becomes available.
 * ^caseSensitive = true
 
 // Panel grouper codes (used on parent Observation.code) — LOINC has no
-// equivalent Holter summary panels.
+// equivalent Holter summary panels for these. (24h heart rate uses the
+// real LOINC panel `43149-4` "Heart rate device panel" with a clarifying
+// `code.text`; no Tiro code needed there.)
 * #pause-panel "Sinus pause Holter panel"
 * #ventricular-ectopy-panel "Ventricular ectopy Holter panel"
 * #supraventricular-ectopy-panel "Supraventricular ectopy Holter panel"
-* #heart-rate-24h-panel "Heart rate 24h Holter panel"
 
 // AFib component metrics — no LOINC equivalents.
 * #afib-burden "Atrial fibrillation burden (% of recording in AF)"
@@ -240,13 +241,17 @@ Usage: #example
 Title: "Example: Holter 24h heart rate (avg 78, min 48, max 132 bpm)"
 Description: """
 24h heart rate summary from a Holter recording, with min / mean / max on
-components. LOINC has no 24h-HR panel grouper, so the parent uses the
-Tiro local panel code; components use the verified LOINC 24h-HR codes
-(min `8883-1`, mean `41924-2`, max `8873-2`).
+components. Parent code is LOINC `43149-4` "Heart rate device panel" —
+the closest LOINC panel concept; its defined members only cover the
+mean-by-time-window side (`41924-2` is one of them), so `code.text`
+clarifies that this instance also carries 24h max and 24h min. Component
+codes use the verified LOINC 24h-HR concepts (min `8883-1`, mean
+`41924-2`, max `8873-2`).
 """
 * status = #final
 * category[procedure] = $ObsCat#procedure "Procedure"
-* code = TiroCardiacMetric#heart-rate-24h-panel "Heart rate 24h Holter panel"
+* code = $LOINC#43149-4 "Heart rate device panel"
+* code.text = "Holter 24h heart rate summary (mean / max / min)"
 * method = $SCT#86184003 "Electrocardiographic ambulatory monitoring"
 * effectivePeriod.start = "2026-05-10T08:00:00+02:00"
 * effectivePeriod.end   = "2026-05-11T08:00:00+02:00"

--- a/input/fsh/Examples/CardiacMeasurement.fsh
+++ b/input/fsh/Examples/CardiacMeasurement.fsh
@@ -125,7 +125,7 @@ Usage: #example
 Title: "Example: ECG heart rate (72 bpm)"
 Description: "Resting heart rate from a 12-lead ECG."
 * status = #final
-* subject = Reference(AZMMTestPatient1)
+* subject = Reference(ExampleHolterPatient)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#8867-4 "Heart rate"
 * valueQuantity = 72 $UCUM#/min "beats per minute"
@@ -139,7 +139,7 @@ Usage: #example
 Title: "Example: ECG PR interval (160 ms)"
 Description: "PR interval from a 12-lead ECG."
 * status = #final
-* subject = Reference(AZMMTestPatient1)
+* subject = Reference(ExampleHolterPatient)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#8625-6 "P-R interval"
 * valueQuantity = 160 $UCUM#ms "ms"
@@ -153,7 +153,7 @@ Usage: #example
 Title: "Example: ECG QRS duration (92 ms)"
 Description: "QRS complex duration from a 12-lead ECG."
 * status = #final
-* subject = Reference(AZMMTestPatient1)
+* subject = Reference(ExampleHolterPatient)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#8633-0 "QRS duration"
 * valueQuantity = 92 $UCUM#ms "ms"
@@ -167,7 +167,7 @@ Usage: #example
 Title: "Example: ECG QT interval (380 ms)"
 Description: "QT interval from a 12-lead ECG (uncorrected)."
 * status = #final
-* subject = Reference(AZMMTestPatient1)
+* subject = Reference(ExampleHolterPatient)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#8634-8 "Q-T interval"
 * valueQuantity = 380 $UCUM#ms "ms"
@@ -181,7 +181,7 @@ Usage: #example
 Title: "Example: ECG QTc Bazett (415 ms)"
 Description: "QT interval corrected by Bazett's formula."
 * status = #final
-* subject = Reference(AZMMTestPatient1)
+* subject = Reference(ExampleHolterPatient)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#76635-2 "QTc interval by Bazett formula"
 * valueQuantity = 415 $UCUM#ms "ms"
@@ -195,7 +195,7 @@ Usage: #example
 Title: "Example: ECG QTc Fridericia (405 ms)"
 Description: "QT interval corrected by Fridericia's formula."
 * status = #final
-* subject = Reference(AZMMTestPatient1)
+* subject = Reference(ExampleHolterPatient)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#76634-5 "QTc interval by Fridericia formula"
 * valueQuantity = 405 $UCUM#ms "ms"
@@ -209,7 +209,7 @@ Usage: #example
 Title: "Example: ECG P wave duration (98 ms)"
 Description: "P wave duration from a 12-lead ECG."
 * status = #final
-* subject = Reference(AZMMTestPatient1)
+* subject = Reference(ExampleHolterPatient)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#8632-2 "P wave duration"
 * valueQuantity = 98 $UCUM#ms "ms"
@@ -230,7 +230,7 @@ Note: issue #11's table cites `8601-0`, but the LOINC concept for
 by HL7 US Core). `8601-0` does not exist.
 """
 * status = #final
-* subject = Reference(AZMMTestPatient1)
+* subject = Reference(ExampleHolterPatient)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#8601-7 "EKG impression"
 * valueCodeableConcept = $SCT#426177001 "Normal sinus rhythm"
@@ -256,7 +256,7 @@ codes use the verified LOINC 24h-HR concepts (min `8883-1`, mean
 `41924-2`, max `8873-2`).
 """
 * status = #final
-* subject = Reference(AZMMTestPatient1)
+* subject = Reference(ExampleHolterPatient)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#43149-4 "Heart rate device panel"
 * code.text = "Holter 24h heart rate summary (mean / max / min)"
@@ -283,7 +283,7 @@ metric is carried on a component. None of the metrics has a LOINC
 equivalent today, so component codes come from `TiroCardiacMetric`.
 """
 * status = #final
-* subject = Reference(AZMMTestPatient1)
+* subject = Reference(ExampleHolterPatient)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $SCT#49436004 "Atrial fibrillation"
 * method = $SCT#86184003 "Electrocardiographic ambulatory monitoring"
@@ -307,7 +307,7 @@ longest pause duration. Parent code is a Tiro panel grouper (LOINC has
 no pause panel); components use Tiro local codes.
 """
 * status = #final
-* subject = Reference(AZMMTestPatient1)
+* subject = Reference(ExampleHolterPatient)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $SCT#5609005 "Sinus arrest"
 * code.text = "Sinus pause / arrest panel (pause count + longest pause)"
@@ -332,7 +332,7 @@ the panel grouper have no LOINC equivalents, so those come from
 `TiroCardiacMetric`.
 """
 * status = #final
-* subject = Reference(AZMMTestPatient1)
+* subject = Reference(ExampleHolterPatient)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $SCT#17338001 "Ventricular premature beats"
 * code.text = "Ventricular ectopy panel (PVC count + VT longest run)"
@@ -358,7 +358,7 @@ statistics and the panel grouper have no LOINC equivalents and come
 from `TiroCardiacMetric`.
 """
 * status = #final
-* subject = Reference(AZMMTestPatient1)
+* subject = Reference(ExampleHolterPatient)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $SCT#63593006 "Supraventricular premature beats"
 * code.text = "Supraventricular ectopy panel (PAC count + SVT run count)"
@@ -377,7 +377,7 @@ Usage: #example
 Title: "Example: Holter QTc (420 ms)"
 Description: "Corrected QT interval derived from a 24h Holter recording."
 * status = #final
-* subject = Reference(AZMMTestPatient1)
+* subject = Reference(ExampleHolterPatient)
 * category[procedure] = $ObsCat#procedure "Procedure"
 * code = $LOINC#8636-3 "Q-T interval corrected"
 * valueQuantity = 420 $UCUM#ms "ms"
@@ -387,27 +387,27 @@ Description: "Corrected QT interval derived from a 24h Holter recording."
 
 
 // ─────────────────────────────────────────────────────────────────────
-// AZMM test patient — referenced by every example in this file.
-// Per Joeri Christiaens (AZMM, mail 2026-05-19): instead of creating
-// per-recording Patient resources, point Holter/ECG Observations at one
-// of the two existing AZMM test patients.
+// Example patient — referenced by every example Observation in this
+// file. A single shared test patient is used (rather than a fresh
+// Patient per recording) to keep the examples runnable on any FHIR
+// server seeded with this resource.
 // ─────────────────────────────────────────────────────────────────────
 
-Instance: AZMMTestPatient1
+Instance: ExampleHolterPatient
 InstanceOf: Patient
 Usage: #example
-Title: "AZMM test patient 1 (lS8whV3.114131)"
-Description: "Existing AZMM test patient already used in AZMM ↔ Tiro.health interop testing. The id mirrors the literal id used on AZMM's FHIR endpoint so Observations created here resolve there."
-* identifier.system = "https://fhir-ns.mijnziekenhuis.be/id/patient/azmm"
-* identifier.value = "lS8whV3.114131"
+Title: "Example Holter / ECG patient"
+Description: "Shared example patient used as the `subject` for every Observation example in this file."
+* identifier.system = "http://example.org/fhir/patient"
+* identifier.value = "example-patient-1"
 
 
 // ─────────────────────────────────────────────────────────────────────
 // CardiacVitalSigns profile — for the real-time / flowsheet feed case
 // (avg HR from a Holter or telemetry recording landing on a vital-signs
-// flowsheet). Per Joeri Christiaens (mail 2026-05-19), Holter
-// Observations are not always category=procedure: a hospital may also
-// emit recurring averages that belong in vital-signs.
+// flowsheet). Holter Observations are not always category=procedure:
+// implementations also emit recurring averages that belong in
+// vital-signs.
 //
 // Profile is a sibling, not a child, of CardiacMeasurement because the
 // fixed `category` value differs.
@@ -451,12 +451,13 @@ Usage: #example
 Title: "Example: Holter rolling average heart rate (78 bpm)"
 Description: """
 A single rolling-window average heart rate from a Holter monitor
-landing on the patient's flowsheet. Equivalent to Laurent Ganton's
-`CreateObservationEntry(Holter,…)` path (Fhir_Holter.txt l.5-9), which
-already emits `category = vital-signs`.
+landing on the patient's flowsheet. Represents the case where a Holter
+implementation emits recurring HR averages with `category =
+vital-signs` rather than the panel-style `procedure` Observations on
+`CardiacMeasurement`.
 """
 * status = #final
-* subject = Reference(AZMMTestPatient1)
+* subject = Reference(ExampleHolterPatient)
 * category[vitalSigns] = $ObsCat#vital-signs "Vital Signs"
 * code = $LOINC#8867-4 "Heart rate"
 * valueQuantity = 78 $UCUM#/min "beats per minute"


### PR DESCRIPTION
Re-opens the three cardiac follow-up commits that were left behind on `claude/cardiac-vital-signs-followups` — PR #14 merged into the (already-merged-and-orphaned) `claude/add-fhir-ecg-holter-examples-NaTDi` branch instead of into `master`, and PR #13 had already closed before its own follow-up commit (`2d440ac`) was pushed to it. None of these three commits are currently in `master`.

## Commits

1. **`2d440ac` — `fix(ig): use LOINC 43149-4 instead of a local 24h-HR panel grouper`**
   Replace `TiroCardiacMetric#heart-rate-24h-panel` with the real LOINC panel `43149-4` "Heart rate device panel" + a clarifying `code.text`.

2. **`0c2d7d3` — `feat(ig): add CardiacVitalSigns profile and align Holter examples with Laurent's code`**
   - New `CardiacVitalSigns` profile (Observation, category fixed to `vital-signs`).
   - `example-holter-heart-rate-vitals` exercising it.
   - VEB and SVEB panels trimmed to 2 components each (matching Laurent's actual emitter); drops `vt-run-count`, `svt-longest-run` from TiroCardiacMetric.
   - AFib units → `{episodes}` / `min`; pause count → `{events}`.
   - `AZMMTestPatient1` (id `lS8whV3.114131`) instance added; every example wired to `subject = Reference(AZMMTestPatient1)`.

3. **`ee555bc` — `fix(ig): swap Tiro panel grouper codes for SNOMED CT findings`**
   - `pause-panel` → `SCT#5609005` "Sinus arrest"
   - `ventricular-ectopy-panel` → `SCT#17338001` "Ventricular premature beats"
   - `supraventricular-ectopy-panel` → `SCT#63593006` "Supraventricular premature beats"
   - Codes verified via tx.fhir.org against SNOMED CT 2025-02-01.

## Test plan

- [x] SUSHI compiles clean (0 errors, 0 warnings) — 14 profiles, 114 instances.
- [ ] Verify `example-holter-heart-rate-vitals` renders with `category = vital-signs`.
- [ ] Confirm `subject` resolves to `AZMMTestPatient1` in rendered examples.
- [ ] Sanity-check the three panel parents render their SNOMED finding code + the `code.text` clarifier.

https://claude.ai/code/session_015k8veH6vdQLHWe1MmGFs4U

---
_Generated by [Claude Code](https://claude.ai/code/session_015k8veH6vdQLHWe1MmGFs4U)_