### PR TITLE
Add Downloads page to Implementation Guide

### DIFF
--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -1,0 +1,55 @@
+# Downloads
+
+This page provides downloadable artifacts for the Tiro.health Implementation Guide.
+
+### Definitions
+
+The following definitions of the artifacts defined as part of this Implementation Guide are available for download. Note that these definitions do not include the narrative content that is found on each of the pages — they are the raw computable artifacts only.
+
+- [JSON](definitions.json.zip)
+- [XML](definitions.xml.zip)
+- [TTL](definitions.ttl.zip)
+
+### Examples
+
+A package containing all the examples used in this Implementation Guide is available:
+
+- [JSON](examples.json.zip)
+- [XML](examples.xml.zip)
+- [TTL](examples.ttl.zip)
+
+### NPM Package
+
+This Implementation Guide is also published as an NPM package for use with FHIR tooling such as the IG Publisher, SUSHI, and the FHIR Validator:
+
+- [Package](package.tgz)
+
+To install via SUSHI, add the following to the `dependencies` section of your `sushi-config.yaml`:
+
+```yaml
+dependencies:
+  tiro-health.fhir: 0.1.0
+```
+
+### Validator Pack
+
+The FHIR Validator Pack contains all the StructureDefinitions, ValueSets, CodeSystems, and other conformance resources needed to validate against this Implementation Guide:
+
+- [Validator Pack](validator.pack)
+
+To validate a resource using the [HL7 FHIR Validator](https://confluence.hl7.org/display/FHIR/Using+the+FHIR+Validator):
+
+```
+java -jar validator_cli.jar -ig tiro-health.fhir#0.1.0 my-resource.json
+```
+
+### Schemas
+
+- [XML Schemas](fhir.schema.json.zip)
+- [JSON Schema](fhir.schema.json.zip)
+
+### Source
+
+The source FHIR Shorthand (FSH) files and full source of this Implementation Guide are available on GitHub:
+
+- [Source Repository](https://github.com/tiro-health/atticus-ig)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -91,6 +91,7 @@ parameters:
 menu:
   Home: index.html
   Artifacts: artifacts.html
+  Downloads: downloads.html
 
 # ╭───────────────────────────Less Common Implementation Guide Properties──────────────────────────╮
 # │  Uncomment the properties below to configure additional properties on the ImplementationGuide  │


### PR DESCRIPTION
## Summary
Added a new Downloads page to the Tiro.health Implementation Guide that provides users with convenient access to downloadable artifacts in multiple formats.

## Changes Made
- **New page:** `input/pagecontent/downloads.md` - Comprehensive downloads page featuring:
  - Definitions (JSON, XML, TTL formats)
  - Examples (JSON, XML, TTL formats)
  - NPM Package with SUSHI installation instructions
  - FHIR Validator Pack with usage examples
  - XML and JSON Schemas
  - Link to source repository on GitHub

- **Updated navigation:** Added "Downloads" menu item to `sushi-config.yaml` to make the new page accessible from the IG's main navigation menu

## Implementation Details
The Downloads page follows the IG's standard documentation format and provides clear instructions for users to:
- Access computable artifacts in their preferred format
- Install the IG as an NPM dependency
- Validate resources using the FHIR Validator
- Access the source code on GitHub

This makes it easier for implementers to discover and utilize the various artifacts provided by the Implementation Guide.

https://claude.ai/code/session_01LhWKYMK4eTFbPfryXfTKAJ